### PR TITLE
fix: force create new settings asset

### DIFF
--- a/Runtime/CoreSettingsHandler.cs
+++ b/Runtime/CoreSettingsHandler.cs
@@ -15,6 +15,12 @@ namespace ReadyPlayerMe.Core
                 if (coreSettings == null)
                 {
                     coreSettings = Resources.Load<CoreSettings>(SETTINGS_PATH);
+#if UNITY_EDITOR
+                    if (coreSettings == null)
+                    {
+                        coreSettings = CreateCoreSettings();
+                    }
+#endif
                 }
                 return coreSettings;
             }
@@ -35,5 +41,18 @@ namespace ReadyPlayerMe.Core
             AssetDatabase.SaveAssets();
 #endif
         }
+        
+#if UNITY_EDITOR
+        private static CoreSettings CreateCoreSettings()
+        {
+            var coreSettings = ScriptableObject.CreateInstance<CoreSettings>();
+            coreSettings.Subdomain = "demo";
+
+            AssetDatabase.CreateAsset(coreSettings, $"Assets/Ready Player Me/Resources/Settings/CoreSettings.asset");
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            return coreSettings;
+        }
+#endif
     }
 }


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.monday.com/boards/2563815861/pulses/TICKETID)

## Description

-  there is currently a number of issues  cause if the core settings asset is not there (or has been deleted) this update fixed that and forces it to be created if it does not exist. 

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Updated

-   CoreSettingsHandler now creates core settings if missing

<!-- Testability -->

## How to Test

-   Add steps to locally test these changes

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



