### PR TITLE
[4026673868] Add operation completed event

### DIFF
--- a/Editor/Analytics/AnalyticsEventLogger.cs
+++ b/Editor/Analytics/AnalyticsEventLogger.cs
@@ -108,7 +108,6 @@ namespace ReadyPlayerMe.Core.Analytics
             });
         }
 
-
         public void LogOpenDialog(string dialog)
         {
             if (!isEnabled) return;
@@ -130,14 +129,20 @@ namespace ReadyPlayerMe.Core.Analytics
             });
         }
 
-        public void LogMetadataDownloaded()
+        public void LogMetadataDownloaded(double duration)
         {
-            amplitudeEventLogger.LogEvent(Constants.EventName.METADATA_DOWNLOADED);
+            amplitudeEventLogger.LogEvent(Constants.EventName.METADATA_DOWNLOADED, new Dictionary<string, object>
+            {
+                { Constants.Properties.DURATION, duration }
+            });
         }
-        
-        public void LogAvatarLoaded()
+
+        public void LogAvatarLoaded(double duration)
         {
-            amplitudeEventLogger.LogEvent(Constants.EventName.AVATAR_LOADED);
+            amplitudeEventLogger.LogEvent(Constants.EventName.AVATAR_LOADED, new Dictionary<string, object>
+            {
+                { Constants.Properties.DURATION, duration }
+            });
         }
 
         private void GenerateSessionId()

--- a/Editor/Analytics/AnalyticsEventLogger.cs
+++ b/Editor/Analytics/AnalyticsEventLogger.cs
@@ -130,6 +130,16 @@ namespace ReadyPlayerMe.Core.Analytics
             });
         }
 
+        public void LogMetadataDownloaded()
+        {
+            amplitudeEventLogger.LogEvent(Constants.EventName.METADATA_DOWNLOADED);
+        }
+        
+        public void LogAvatarLoaded()
+        {
+            amplitudeEventLogger.LogEvent(Constants.EventName.AVATAR_LOADED);
+        }
+
         private void GenerateSessionId()
         {
             amplitudeEventLogger.SetSessionId(DateTimeOffset.Now.ToUnixTimeMilliseconds());

--- a/Editor/Analytics/Constants.cs
+++ b/Editor/Analytics/Constants.cs
@@ -37,6 +37,7 @@ namespace ReadyPlayerMe.Core.Analytics
             public const string AVATAR_URL = "avatar url";
             public const string APP_IDENTIFIER = "app identifier";
             public const string ALLOW_ANALYTICS = "allow analytics";
+            public const string DURATION = "duration";
         }
 
         public static class AmplitudeKeys

--- a/Editor/Analytics/Constants.cs
+++ b/Editor/Analytics/Constants.cs
@@ -14,6 +14,8 @@ namespace ReadyPlayerMe.Core.Analytics
             public const string OPEN_DIALOG = "open dialog";
             public const string BUILD_APPLICATION = "build application";
             public const string CLOSE_PROJECT = "close project";
+            public const string METADATA_DOWNLOADED = "metadata downloaded";
+            public const string AVATAR_LOADED = "avatar loaded";
             public const string SET_USER_PROPERTIES = "set user properties";
         }
 

--- a/Editor/Analytics/IAnalyticsEventLogger.cs
+++ b/Editor/Analytics/IAnalyticsEventLogger.cs
@@ -14,5 +14,8 @@ namespace ReadyPlayerMe.Core.Analytics
         void LogUpdatePartnerURL(string previousSubdomain, string newSubdomain);
         void LogOpenDialog(string dialog);
         void LogBuildApplication(string target, string appName, bool productionBuild);
+        void LogMetadataDownloaded();
+        void LogAvatarLoaded();
+
     }
 }

--- a/Editor/Analytics/IAnalyticsEventLogger.cs
+++ b/Editor/Analytics/IAnalyticsEventLogger.cs
@@ -14,8 +14,8 @@ namespace ReadyPlayerMe.Core.Analytics
         void LogUpdatePartnerURL(string previousSubdomain, string newSubdomain);
         void LogOpenDialog(string dialog);
         void LogBuildApplication(string target, string appName, bool productionBuild);
-        void LogMetadataDownloaded();
-        void LogAvatarLoaded();
+        void LogMetadataDownloaded(double duration);
+        void LogAvatarLoaded(double duration);
 
     }
 }

--- a/Runtime/OperationExecutor.cs
+++ b/Runtime/OperationExecutor.cs
@@ -10,11 +10,14 @@ namespace ReadyPlayerMe.Core
         private readonly IOperation<T>[] operations;
         private readonly int operationsCount;
 
+        public int Timeout;
+        public Action<IOperation<T>> OperationCompleted;
+
         private CancellationTokenSource ctxSource;
         private int currentIndex;
 
         private float currentProgress;
-        public int Timeout;
+        
 
         public OperationExecutor(IOperation<T>[] operations)
         {
@@ -28,7 +31,7 @@ namespace ReadyPlayerMe.Core
         public async Task<T> Execute(T context)
         {
             ctxSource = new CancellationTokenSource();
-            foreach (IOperation<T> operation in operations)
+            foreach (var operation in operations)
             {
                 operation.ProgressChanged += OnProgressChanged;
                 operation.Timeout = Timeout;
@@ -47,6 +50,7 @@ namespace ReadyPlayerMe.Core
                     throw;
                 }
                 operation.ProgressChanged -= OnProgressChanged;
+                OperationCompleted?.Invoke(operation);
             }
 
             return context;


### PR DESCRIPTION
## [4026673868](https://ready-player-me.monday.com/boards/2563815861/pulses/4026673868)

## Description

- Extended OperationExecutor with extra event and added new events for analytics.

## Changes

#### Added

- OperationCompleted event to OperationExecutor
- Event name constants and functions for avatar loaded and metadata downloaded

## How to Test

- Should be tested with `feature/avatar-loaded-events` branch of avatar loader module
- Try loading avatar from editor window and observe analytics event on amplitude
- Note: analytics should be enabled

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



