### PR TITLE
SDK-145 chore: added timeout

### DIFF
--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -6,6 +6,7 @@ using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEditor.PackageManager;
 using UnityEditor.PackageManager.Requests;
+using UnityEngine;
 using PackageInfo = UnityEditor.PackageManager.PackageInfo;
 
 namespace ReadyPlayerMe.Core.Editor
@@ -29,6 +30,8 @@ namespace ReadyPlayerMe.Core.Editor
         private const string MODULE_INSTALLATION_FAILURE_MESSAGE = "Something went wrong while installing modules.";
         private const string ALL_MODULES_ARE_INSTALLED = "All modules are installed.";
         private const string INSTALLING_MODULES = "Installing modules...";
+
+        private const float TIMEOUT_FOR_MODULE_INSTALLATION = 20f;
 
         static ModuleInstaller()
         {
@@ -102,15 +105,21 @@ namespace ReadyPlayerMe.Core.Editor
         /// <param name="identifier">The Unity package identifier of the module to be installed.</param>
         public static void AddModuleRequest(string identifier)
         {
+            var startTime = Time.realtimeSinceStartup;
             AddRequest addRequest = Client.Add(identifier);
-            while (!addRequest.IsCompleted)
+            while (!addRequest.IsCompleted && Time.realtimeSinceStartup - startTime < TIMEOUT_FOR_MODULE_INSTALLATION)
                 Thread.Sleep(THREAD_SLEEP_TIME);
 
+
+            if (Time.realtimeSinceStartup - startTime >= TIMEOUT_FOR_MODULE_INSTALLATION)
+            {
+                Debug.LogError($"Package installation timed out for {identifier}. Please try again.");
+            }
             if (addRequest.Error != null)
             {
                 AssetDatabase.Refresh();
                 CompilationPipeline.RequestScriptCompilation();
-                SDKLogger.Log(TAG, "Error: " + addRequest.Error.message);
+                Debug.LogError("Error: " + addRequest.Error.message);
             }
         }
 


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-145](https://ready-player-me.atlassian.net/browse/SDK-145)

<!-- Replace the branch with the dependency, if no dependency is required than set this to develop -->
## Dependencies
```Package
Avatar Loader: develop
```

## Description

-   adds a timeout to the module installer to prevent importer getting stuck

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Added

-   timeout to the module installer to prevent importer getting stuck

<!-- Testability -->

## How to Test

-   You can try importing our package and then immediately turning off wifi/internet connection although this may not actually trigger the timeout, but instead request errors 

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-145]: https://ready-player-me.atlassian.net/browse/SDK-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ