### PR TITLE
[SDK-185] Feature/setup guide fix

### DIFF
--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -32,6 +32,7 @@ namespace ReadyPlayerMe.Core.Editor
         private const string INSTALLING_MODULES = "Installing modules...";
 
         private const float TIMEOUT_FOR_MODULE_INSTALLATION = 20f;
+        private const string AVATAR_LOADER_SUBSTRING = "avatarloader";
 
         static ModuleInstaller()
         {
@@ -107,6 +108,12 @@ namespace ReadyPlayerMe.Core.Editor
         {
             var startTime = Time.realtimeSinceStartup;
             AddRequest addRequest = Client.Add(identifier);
+
+            // reset first time setup flag to ensure setup guide window is displayed
+            if (identifier.Contains(AVATAR_LOADER_SUBSTRING))
+            {
+                ProjectPrefs.SetBool(ProjectPrefs.FIRST_TIME_SETUP_DONE, false);
+            }
             while (!addRequest.IsCompleted && Time.realtimeSinceStartup - startTime < TIMEOUT_FOR_MODULE_INSTALLATION)
                 Thread.Sleep(THREAD_SLEEP_TIME);
 

--- a/Editor/Module Management/ModuleList.cs
+++ b/Editor/Module Management/ModuleList.cs
@@ -33,7 +33,7 @@ namespace ReadyPlayerMe.Core.Editor
             {
                 name = "com.readyplayerme.avatarloader",
                 gitUrl = "https://github.com/readyplayerme/rpm-unity-sdk-avatar-loader.git",
-                branch = "",
+                branch = "feature/setup-guide-fix",
                 version = "1.3.0"
             },
             new ModuleInfo

--- a/Editor/Utils/ProjectPrefs.cs
+++ b/Editor/Utils/ProjectPrefs.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 
 public static class ProjectPrefs
 {
+    public const string FIRST_TIME_SETUP_DONE = "first-time-setup-guide";
+
     public static bool GetBool(string key)
     {
         return EditorPrefs.GetBool($"{Application.dataPath}{key}");


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-185](https://ready-player-me.atlassian.net/browse/SDK-185)

<!-- Replace the branch with the dependency, if no dependency is required than set this to develop -->
## Dependencies
```Package
Avatar Loader: feature/setup-guide-fix
```

## Description

-   This PR includes some changes to the module installer so that it resets the avatar loader setup guide project pref to ensure the setup guide is displayed whenever avatar loader package is downloaded/ redownloaded
- also includes some refactoring of project prefs script 

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Updated

-   added logic to module installer reset setup guide project pref


<!-- Testability -->

## How to Test

to test, open a project and
-  add this git URL to package manager https://github.com/readyplayerme/rpm-unity-sdk-core.git#feature/setup-guide-fix 
- go through the setup guide
- then delete/remove the RPM packages
- Then re-add core from above URL 
- it should display the setup guide again the fix works correctly

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-185]: https://ready-player-me.atlassian.net/browse/SDK-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ