### PR TITLE
[SDK-219] fix: move open project event logic

### DIFF
--- a/.github/latest.md
+++ b/.github/latest.md
@@ -3,4 +3,4 @@ This hotfix includes an updated avatar loader version.
 ## Changelog
 
 ### Fixed
-- avatar loader version update to fix setup guide window
+- an issue causing incorrect analytics event logging

--- a/Editor/Module Management/ModuleList.cs
+++ b/Editor/Module Management/ModuleList.cs
@@ -13,8 +13,8 @@ namespace ReadyPlayerMe.Core.Editor
         {
             name = "com.readyplayerme.core",
             gitUrl = "https://github.com/readyplayerme/rpm-unity-sdk-core.git",
-            branch = "",
-            version = "1.3.2"
+            branch = "hotfix/1.3.3",
+            version = "1.3.3"
         };
 
         /// <summary>
@@ -33,8 +33,8 @@ namespace ReadyPlayerMe.Core.Editor
             {
                 name = "com.readyplayerme.avatarloader",
                 gitUrl = "https://github.com/readyplayerme/rpm-unity-sdk-avatar-loader.git",
-                branch = "",
-                version = "1.3.3"
+                branch = "hotfix/1.3.4",
+                version = "1.3.4"
             },
             new ModuleInfo
             {

--- a/Editor/Module Management/ModuleList.cs
+++ b/Editor/Module Management/ModuleList.cs
@@ -13,7 +13,7 @@ namespace ReadyPlayerMe.Core.Editor
         {
             name = "com.readyplayerme.core",
             gitUrl = "https://github.com/readyplayerme/rpm-unity-sdk-core.git",
-            branch = "hotfix/1.3.3",
+            branch = "",
             version = "1.3.3"
         };
 
@@ -33,7 +33,7 @@ namespace ReadyPlayerMe.Core.Editor
             {
                 name = "com.readyplayerme.avatarloader",
                 gitUrl = "https://github.com/readyplayerme/rpm-unity-sdk-avatar-loader.git",
-                branch = "hotfix/1.3.4",
+                branch = "",
                 version = "1.3.4"
             },
             new ModuleInfo

--- a/Editor/Utils/EntryPoint.cs
+++ b/Editor/Utils/EntryPoint.cs
@@ -1,4 +1,5 @@
 using System;
+using ReadyPlayerMe.Core.Analytics;
 using UnityEditor;
 
 namespace ReadyPlayerMe.Core.Editor
@@ -19,7 +20,11 @@ namespace ReadyPlayerMe.Core.Editor
         /// </summary>
         static EntryPoint()
         {
-            EditorApplication.update += Update;
+            if (!SessionState.GetBool(SESSION_STARTED_KEY, false))
+            {
+                SessionState.SetBool(SESSION_STARTED_KEY, true);
+                EditorApplication.update += Update;
+            }
         }
 
         /// <summary>
@@ -28,12 +33,11 @@ namespace ReadyPlayerMe.Core.Editor
         /// </summary>
         private static void Update()
         {
-            if (SessionState.GetBool(SESSION_STARTED_KEY, false)) return;
-            SessionState.SetBool(SESSION_STARTED_KEY, true);
-
+            EditorApplication.update -= Update;
+            AnalyticsEditorLogger.EventLogger.LogOpenProject();
+            AnalyticsEditorLogger.EventLogger.IdentifyUser();
             Startup?.Invoke();
             ModuleUpdater.CheckForUpdates();
-            EditorApplication.update -= Update;
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.readyplayerme.core",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "displayName": "Ready Player Me Core",
   "description": "Ready Player Me Core is responsible for module management and setting up the SDK for first time use.",
   "unity": "2020.3",


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.atlassian.net/browse/TICKETID)

<!-- Replace the branch with the dependency, if no dependency is required than set this to develop -->
## Dependencies
```Package
Avatar Loader: hotfix/1.3.4
```

## Description

-   This change includes a fix for an issue that caused the log project open and identify user events being fired every time unity recompiles

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Added

-   List your additions and new features here.

#### Updated

-   List your updates and changes here.

#### Removed

-   List what is removed here.

<!-- Testability -->

## How to Test

-   Add steps to locally test these changes

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



