### PR TITLE
[SDK-321] Feature/gtlfast symbol fix

### DIFF
--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -189,8 +189,7 @@ namespace ReadyPlayerMe.Core.Editor
             SetDefineSymbol(BuildTargetGroup.WebGL);
             SetDefineSymbol(BuildTargetGroup.Android);
             SetDefineSymbol(BuildTargetGroup.iOS);
-            CompilationPipeline.RequestScriptCompilation();
-            CodeEditor.CurrentEditor.SyncAll();
+            BuildPipeline.BuildPlayer(new BuildPlayerOptions());
         }
 
         private static void SetDefineSymbol(BuildTargetGroup target)

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -39,6 +39,9 @@ namespace ReadyPlayerMe.Core.Editor
 
         static ModuleInstaller()
         {
+    #if !GLTFAST
+            AddGltfastSymbol();
+    #endif
             Events.registeredPackages += OnRegisteredPackages;
             Events.registeringPackages += OnRegisteringPackages;
         }
@@ -57,12 +60,10 @@ namespace ReadyPlayerMe.Core.Editor
             // Core Module installed
             if (args.added != null && args.added.Any(p => p.name == CORE_MODULE_NAME))
             {
-                AddScriptingDefineSymbolToAllBuildTargetGroups(READY_PLAYER_ME_SYMBOL);
                 InstallModules();
                 CoreSettingsHandler.CreateCoreSettings();
-#if !GLTFAST
+                AddScriptingDefineSymbolToAllBuildTargetGroups(READY_PLAYER_ME_SYMBOL);
                 AddGltfastSymbol();
-#endif
             }
             ValidateModules();
         }

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -39,8 +39,6 @@ namespace ReadyPlayerMe.Core.Editor
 
         static ModuleInstaller()
         {
-            AddScriptingDefineSymbolToAllBuildTargetGroups(READY_PLAYER_ME_SYMBOL);
-            AddScriptingDefineSymbolToAllBuildTargetGroups(GLTFAST_SYMBOL);
             Events.registeredPackages += OnRegisteredPackages;
             Events.registeringPackages += OnRegisteringPackages;
         }
@@ -59,9 +57,10 @@ namespace ReadyPlayerMe.Core.Editor
             // Core Module installed
             if (args.added != null && args.added.Any(p => p.name == CORE_MODULE_NAME))
             {
+                AddScriptingDefineSymbolToAllBuildTargetGroups(READY_PLAYER_ME_SYMBOL);
+                AddScriptingDefineSymbolToAllBuildTargetGroups(GLTFAST_SYMBOL);
                 InstallModules();
                 CoreSettingsHandler.CreateCoreSettings();
-                CompilationPipeline.RequestScriptCompilation();
             }
             ValidateModules();
         }
@@ -107,6 +106,10 @@ namespace ReadyPlayerMe.Core.Editor
             }
 
             EditorUtility.ClearProgressBar();
+            CompilationPipeline.RequestScriptCompilation();
+            EditorUtility.RequestScriptReload();
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
         }
 
         /// <summary>

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -58,9 +58,11 @@ namespace ReadyPlayerMe.Core.Editor
             if (args.added != null && args.added.Any(p => p.name == CORE_MODULE_NAME))
             {
                 AddScriptingDefineSymbolToAllBuildTargetGroups(READY_PLAYER_ME_SYMBOL);
-                AddScriptingDefineSymbolToAllBuildTargetGroups(GLTFAST_SYMBOL);
                 InstallModules();
                 CoreSettingsHandler.CreateCoreSettings();
+#if !GLTFAST
+            UnityEditor.Compilation.CompilationPipeline.RequestScriptCompilation();
+#endif
             }
             ValidateModules();
         }
@@ -106,10 +108,6 @@ namespace ReadyPlayerMe.Core.Editor
             }
 
             EditorUtility.ClearProgressBar();
-            CompilationPipeline.RequestScriptCompilation();
-            EditorUtility.RequestScriptReload();
-            AssetDatabase.SaveAssets();
-            AssetDatabase.Refresh();
         }
 
         /// <summary>
@@ -137,6 +135,10 @@ namespace ReadyPlayerMe.Core.Editor
             if (addRequest.Error != null)
             {
                 AssetDatabase.Refresh();
+                if (identifier.Contains("gltfast"))
+                {
+                    AddScriptingDefineSymbolToAllBuildTargetGroups(GLTFAST_SYMBOL);
+                }
                 CompilationPipeline.RequestScriptCompilation();
                 Debug.LogError("Error: " + addRequest.Error.message);
             }

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Unity.CodeEditor;
 using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEditor.PackageManager;
@@ -189,6 +190,7 @@ namespace ReadyPlayerMe.Core.Editor
             SetDefineSymbol(BuildTargetGroup.Android);
             SetDefineSymbol(BuildTargetGroup.iOS);
             CompilationPipeline.RequestScriptCompilation();
+            CodeEditor.CurrentEditor.SyncAll();
         }
 
         private static void SetDefineSymbol(BuildTargetGroup target)

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -61,7 +61,7 @@ namespace ReadyPlayerMe.Core.Editor
                 InstallModules();
                 CoreSettingsHandler.CreateCoreSettings();
 #if !GLTFAST
-            UnityEditor.Compilation.CompilationPipeline.RequestScriptCompilation();
+                AddGltfastSymbol();
 #endif
             }
             ValidateModules();
@@ -135,10 +135,6 @@ namespace ReadyPlayerMe.Core.Editor
             if (addRequest.Error != null)
             {
                 AssetDatabase.Refresh();
-                if (identifier.Contains("gltfast"))
-                {
-                    AddScriptingDefineSymbolToAllBuildTargetGroups(GLTFAST_SYMBOL);
-                }
                 CompilationPipeline.RequestScriptCompilation();
                 Debug.LogError("Error: " + addRequest.Error.message);
             }
@@ -185,6 +181,11 @@ namespace ReadyPlayerMe.Core.Editor
             return listRequest.Result.ToArray();
         }
 
+        public static void AddGltfastSymbol()
+        {
+            AddScriptingDefineSymbolToAllBuildTargetGroups(GLTFAST_SYMBOL);
+        }
+
         private static void AddScriptingDefineSymbolToAllBuildTargetGroups(string defineSymbol)
         {
             foreach (BuildTarget target in Enum.GetValues(typeof(BuildTarget)))
@@ -209,6 +210,8 @@ namespace ReadyPlayerMe.Core.Editor
                     Debug.LogWarning("Could not set RPM " + defineSymbol + " defines for build target: " + target + " group: " + group + " " + e);
                 }
             }
+
+            CompilationPipeline.RequestScriptCompilation();
         }
 
         /// <summary>

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -188,6 +188,7 @@ namespace ReadyPlayerMe.Core.Editor
             SetDefineSymbol(BuildTargetGroup.WebGL);
             SetDefineSymbol(BuildTargetGroup.Android);
             SetDefineSymbol(BuildTargetGroup.iOS);
+            CompilationPipeline.RequestScriptCompilation();
         }
 
         private static void SetDefineSymbol(BuildTargetGroup target)

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -127,15 +127,12 @@ namespace ReadyPlayerMe.Core.Editor
             while (!addRequest.IsCompleted && Time.realtimeSinceStartup - startTime < TIMEOUT_FOR_MODULE_INSTALLATION)
                 Thread.Sleep(THREAD_SLEEP_TIME);
 
-
             if (Time.realtimeSinceStartup - startTime >= TIMEOUT_FOR_MODULE_INSTALLATION)
             {
                 Debug.LogError($"Package installation timed out for {identifier}. Please try again.");
             }
             if (addRequest.Error != null)
             {
-                AssetDatabase.Refresh();
-                CompilationPipeline.RequestScriptCompilation();
                 Debug.LogError("Error: " + addRequest.Error.message);
             }
         }

--- a/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
+++ b/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
@@ -31,6 +31,9 @@ namespace ReadyPlayerMe.Core.Editor
             var window = GetWindow<AvatarLoaderEditor>();
             window.titleContent = new GUIContent(AVATAR_LOADER);
             window.minSize = new Vector2(500, 300);
+// #if !GLTFAST
+//             UnityEditor.Compilation.CompilationPipeline.RequestScriptCompilation();
+// #endif
         }
 
         public void CreateGUI()

--- a/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
+++ b/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
@@ -28,12 +28,12 @@ namespace ReadyPlayerMe.Core.Editor
         [MenuItem("Ready Player Me/Avatar Loader", priority = 0)]
         public static void ShowWindow()
         {
+#if !GLTFAST
+            ModuleInstaller.AddGltfastSymbol();
+#endif
             var window = GetWindow<AvatarLoaderEditor>();
             window.titleContent = new GUIContent(AVATAR_LOADER);
             window.minSize = new Vector2(500, 300);
-// #if !GLTFAST
-//             UnityEditor.Compilation.CompilationPipeline.RequestScriptCompilation();
-// #endif
         }
 
         public void CreateGUI()

--- a/Editor/UI/EditorWindows/SetupGuide/OneTimeSetup.cs
+++ b/Editor/UI/EditorWindows/SetupGuide/OneTimeSetup.cs
@@ -27,7 +27,6 @@ namespace ReadyPlayerMe.Core.Editor
                 AnalyticsEditorLogger.EventLogger.LogOpenProject();
                 AnalyticsEditorLogger.EventLogger.IdentifyUser();
                 EditorApplication.quitting += OnQuit;
-
             }
         }
 


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-321](https://ready-player-me.atlassian.net/browse/SDK-321)

## Description

-   This PR adds a fix for handling an issue where GLTFAST symbol is not recognized after being added. 
Please test on a new FRESH project by importing from this URL 
`https://github.com/readyplayerme/rpm-unity-sdk-core.git#feature/gtlfast-symbol-fix`

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   create new Unity project with unique project name and import package from this branch 
`https://github.com/readyplayerme/rpm-unity-sdk-core.git#feature/gtlfast-symbol-fix`
Then try to immediately load an avatar from Avatar Loader window
![image](https://github.com/readyplayerme/rpm-unity-sdk-core/assets/7085672/dffb75f7-54bc-4e3b-b0bb-3bf9c5b3e185)


<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-321]: https://ready-player-me.atlassian.net/browse/SDK-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ