### PR TITLE
fix: rework prefab creation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.1] - 2023.08.28
+
+### Fixed
+- issue of missing mesh references when prefabs were created by avatar loader window
+
 ## [3.2.0] - 2023.08.24
 
 ### Added

--- a/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
+++ b/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
@@ -123,10 +123,17 @@ namespace ReadyPlayerMe.Core.Editor
             }
 
             var paramHash = AvatarCache.GetAvatarConfigurationHash(avatarLoaderSettings.AvatarConfig);
-            EditorUtilities.CreatePrefab(avatar, $"{DirectoryUtility.GetRelativeProjectPath(avatar.name, paramHash)}/{avatar.name}.prefab");
-
+            var modelFilePath = $"{DirectoryUtility.GetRelativeProjectPath(avatar.name, paramHash)}/{avatar.name}.glb";
+            AssetDatabase.Refresh();
+            Object source = AssetDatabase.LoadAssetAtPath(modelFilePath, typeof(GameObject));
+            var objSource = (GameObject) PrefabUtility.InstantiatePrefab(source);
+            var avatarProcessor = new AvatarProcessor();
+            PrefabUtility.UnpackPrefabInstance(objSource, PrefabUnpackMode.Completely, InteractionMode.AutomatedAction);
+            avatarProcessor.ProcessAvatar(objSource, args.Metadata);
+            EditorUtilities.CreatePrefab(objSource, $"{DirectoryUtility.GetRelativeProjectPath(avatar.name, paramHash)}/{avatar.name}.prefab");
             Selection.activeObject = args.Avatar;
             AnalyticsEditorLogger.EventLogger.LogAvatarLoaded(EditorApplication.timeSinceStartup - startTime);
+            DestroyImmediate(objSource);
         }
     }
 }

--- a/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
+++ b/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
@@ -125,7 +125,6 @@ namespace ReadyPlayerMe.Core.Editor
             DestroyImmediate(args.Avatar, true);
             Selection.activeObject = avatar;
             AnalyticsEditorLogger.EventLogger.LogAvatarLoaded(EditorApplication.timeSinceStartup - startTime);
-
         }
     }
 }

--- a/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
+++ b/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
@@ -113,27 +113,19 @@ namespace ReadyPlayerMe.Core.Editor
 
         private void Completed(object sender, CompletionEventArgs args)
         {
-            GameObject avatar = args.Avatar;
-
-            if (useEyeAnimations) avatar.AddComponent<EyeAnimationHandler>();
-            if (useVoiceToAnim) avatar.AddComponent<VoiceHandler>();
             if (avatarLoaderSettings == null)
             {
                 avatarLoaderSettings = AvatarLoaderSettings.LoadSettings();
             }
-
             var paramHash = AvatarCache.GetAvatarConfigurationHash(avatarLoaderSettings.AvatarConfig);
-            var modelFilePath = $"{DirectoryUtility.GetRelativeProjectPath(avatar.name, paramHash)}/{avatar.name}.glb";
-            AssetDatabase.Refresh();
-            Object source = AssetDatabase.LoadAssetAtPath(modelFilePath, typeof(GameObject));
-            var objSource = (GameObject) PrefabUtility.InstantiatePrefab(source);
-            var avatarProcessor = new AvatarProcessor();
-            PrefabUtility.UnpackPrefabInstance(objSource, PrefabUnpackMode.Completely, InteractionMode.AutomatedAction);
-            avatarProcessor.ProcessAvatar(objSource, args.Metadata);
-            EditorUtilities.CreatePrefab(objSource, $"{DirectoryUtility.GetRelativeProjectPath(avatar.name, paramHash)}/{avatar.name}.prefab");
-            Selection.activeObject = args.Avatar;
+            var path = $"{DirectoryUtility.GetRelativeProjectPath(args.Avatar.name, paramHash)}/{args.Avatar.name}";
+            GameObject avatar = EditorUtilities.CreateAvatarPrefab(args.Metadata, path);
+            if (useEyeAnimations) avatar.AddComponent<EyeAnimationHandler>();
+            if (useVoiceToAnim) avatar.AddComponent<VoiceHandler>();
+            DestroyImmediate(args.Avatar, true);
+            Selection.activeObject = avatar;
             AnalyticsEditorLogger.EventLogger.LogAvatarLoaded(EditorApplication.timeSinceStartup - startTime);
-            DestroyImmediate(objSource);
+
         }
     }
 }

--- a/Editor/Utils/EditorUtilities.cs
+++ b/Editor/Utils/EditorUtilities.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace ReadyPlayerMe.Core.Editor
 {
@@ -38,6 +39,22 @@ namespace ReadyPlayerMe.Core.Editor
         {
             return !string.IsNullOrEmpty(urlString) &&
                    (Regex.Match(urlString, SHORT_CODE_REGEX).Length > 0 || Uri.IsWellFormedUriString(urlString, UriKind.Absolute) && urlString.EndsWith(".glb"));
+        }
+
+        public static GameObject CreateAvatarPrefab(AvatarMetadata avatarMetadata, string path)
+        {
+            var modelFilePath = $"{path}.glb";
+            AssetDatabase.Refresh();
+            Object avatarSource = AssetDatabase.LoadAssetAtPath(modelFilePath, typeof(GameObject));
+            var newAvatar = (GameObject) PrefabUtility.InstantiatePrefab(avatarSource);
+            var avatarProcessor = new AvatarProcessor();
+            PrefabUtility.UnpackPrefabInstance(newAvatar, PrefabUnpackMode.Completely, InteractionMode.AutomatedAction);
+            avatarProcessor.ProcessAvatar(newAvatar, avatarMetadata);
+            var avatarData = newAvatar.AddComponent<AvatarData>();
+            avatarData.AvatarMetadata = avatarMetadata;
+            avatarData.AvatarId = newAvatar.name;
+            CreatePrefab(newAvatar, $"{path}.prefab");
+            return newAvatar;
         }
     }
 }

--- a/Runtime/AvatarObjectLoader.cs
+++ b/Runtime/AvatarObjectLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using GLTFast;
 using ReadyPlayerMe.Loader;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -73,7 +74,7 @@ namespace ReadyPlayerMe.Core
             avatarUrl = url;
             Load(url);
         }
-        
+
         /// <summary>
         /// Load avatar asynchronously from a URL and return the result as eventArgs.
         /// </summary>
@@ -92,12 +93,12 @@ namespace ReadyPlayerMe.Core
                 eventArgs = args;
                 isCompleted = true;
             };
-            
+
             startTime = Time.timeSinceLevelLoad;
             SDKLogger.Log(TAG, $"Started loading avatar with config {(AvatarConfig ? AvatarConfig.name : "None")} from URL {url}");
             avatarUrl = url;
             Load(url);
-            
+
             while (!isCompleted)
             {
                 await Task.Yield();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.readyplayerme.core",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "displayName": "Ready Player Me Core",
   "description": "This Module contains all the core functionality required for using Ready Player Me avatars in Unity, including features such as: \n - Module management and automatic package setup logic\n - Avatar loading from .glb files\n - Avatar and 2D render requests\n - Optional Analytics\n - Custom editor windows\n - Sample scenes and assets",
   "unity": "2020.3",


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-380](https://ready-player-me.atlassian.net/browse/SDK-380)

## Description

-   there is currently an issue that when a prefab is created during the process of loading an avatar from Avatar Loader window all the mesh and material references are lost. They are applied to object in the scene but are not applied to the prefab (it seems a unity bug/limitation. 
https://forum.unity.com/threads/not-able-to-prefab-meshes-created-through-script.1302210/

![Screenshot 2023-08-25 111512](https://github.com/readyplayerme/rpm-unity-sdk-core/assets/7085672/57886164-ba7a-4ffd-8a6e-6fede42a208b)


<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   Add steps to locally test these changes

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-380]: https://ready-player-me.atlassian.net/browse/SDK-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ