### PR TITLE
Hotfix/v3.2.2

### DIFF
--- a/.github/latest.md
+++ b/.github/latest.md
@@ -2,5 +2,5 @@
 ## Changelog
 
 ### Fixed
-- issue of missing mesh references when prefabs were created by avatar loader window
+- issue where order of operations caused scriptable object creation errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.2.2] - 2023.08.29
+## [3.2.2] - 2023.08.30
 
 ### Fixed
 - issue where order of operations caused scriptable object creation errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.2] - 2023.08.29
+
+### Fixed
+- issue where order of operations caused scriptable object creation errors
+
 ## [3.2.1] - 2023.08.28
 
 ### Fixed

--- a/Editor/EditorAssetGenerator.cs
+++ b/Editor/EditorAssetGenerator.cs
@@ -13,6 +13,11 @@ namespace ReadyPlayerMe.Core.Editor
         {
             EditorApplication.delayCall += CreateSettingsAssets;
         }
+        
+        ~EditorAssetGenerator()
+        {
+            EditorApplication.delayCall -= CreateSettingsAssets;
+        }
 
         private static void CreateSettingsAssets()
         {

--- a/Editor/EditorAssetGenerator.cs
+++ b/Editor/EditorAssetGenerator.cs
@@ -10,7 +10,7 @@ namespace ReadyPlayerMe.Core.Editor
 
         static EditorAssetGenerator()
         {
-            CreateSettingsAssets();
+            EditorApplication.delayCall += CreateSettingsAssets;
         }
 
         private static void CreateSettingsAssets()

--- a/Editor/EditorAssetGenerator.cs
+++ b/Editor/EditorAssetGenerator.cs
@@ -11,10 +11,7 @@ namespace ReadyPlayerMe.Core.Editor
 
         static EditorAssetGenerator()
         {
-            if (!Resources.Load<AvatarLoaderSettings>(AvatarLoaderSettings.SETTINGS_PATH))
-            {
-                CreateSettingsAssets();
-            }
+            CreateSettingsAssets();
         }
 
         private static void CreateSettingsAssets()

--- a/Editor/EditorAssetGenerator.cs
+++ b/Editor/EditorAssetGenerator.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 
 namespace ReadyPlayerMe.Core.Editor
 {
-    [InitializeOnLoad]
     public class EditorAssetGenerator
     {
         private const string SETTINGS_SAVE_FOLDER = "Ready Player Me/Resources/Settings";

--- a/Editor/EditorAssetGenerator.cs
+++ b/Editor/EditorAssetGenerator.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace ReadyPlayerMe.Core.Editor
 {
+    [InitializeOnLoad]
     public class EditorAssetGenerator
     {
         private const string SETTINGS_SAVE_FOLDER = "Ready Player Me/Resources/Settings";

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -40,14 +40,10 @@ namespace ReadyPlayerMe.Core.Editor
 
         static ModuleInstaller()
         {
-    #if !GLTFAST
-            AddGltfastSymbol();
-    #endif
             Events.registeredPackages += OnRegisteredPackages;
             Events.registeringPackages += OnRegisteringPackages;
         }
-
-
+        
         /// <summary>
         ///     Called when a package is added, removed or changed.
         /// </summary>

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -178,11 +178,6 @@ namespace ReadyPlayerMe.Core.Editor
 
         public static void AddGltfastSymbol()
         {
-            if(Type.GetType(GLTFAST_CLASS)  == null)
-            {
-                SDKLogger.Log(TAG, "GLTFast is not installed. Do not add scripting define symbol.");
-                return;
-            }
             AddScriptingDefineSymbolToAllBuildTargetGroups(GLTFAST_SYMBOL);
         }
 

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -62,9 +62,9 @@ namespace ReadyPlayerMe.Core.Editor
             if (args.added != null && args.added.Any(p => p.name == CORE_MODULE_NAME))
             {
                 InstallModules();
+                AddGltfastSymbol();
                 CoreSettingsHandler.CreateCoreSettings();
                 AddScriptingDefineSymbolToAllBuildTargetGroups(READY_PLAYER_ME_SYMBOL);
-                AddGltfastSymbol();
             }
             ValidateModules();
         }

--- a/Editor/Module Management/ModuleInstaller.cs
+++ b/Editor/Module Management/ModuleInstaller.cs
@@ -35,6 +35,7 @@ namespace ReadyPlayerMe.Core.Editor
 
         private const float TIMEOUT_FOR_MODULE_INSTALLATION = 20f;
         private const string AVATAR_LOADER_SUBSTRING = "avatarloader";
+        private const string GLTFAST_CLASS = "GLTFast.GltfAsset";
 
 
         static ModuleInstaller()
@@ -181,6 +182,11 @@ namespace ReadyPlayerMe.Core.Editor
 
         public static void AddGltfastSymbol()
         {
+            if(Type.GetType(GLTFAST_CLASS)  == null)
+            {
+                SDKLogger.Log(TAG, "GLTFast is not installed. Do not add scripting define symbol.");
+                return;
+            }
             AddScriptingDefineSymbolToAllBuildTargetGroups(GLTFAST_SYMBOL);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.readyplayerme.core",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "displayName": "Ready Player Me Core",
   "description": "This Module contains all the core functionality required for using Ready Player Me avatars in Unity, including features such as: \n - Module management and automatic package setup logic\n - Avatar loading from .glb files\n - Avatar and 2D render requests\n - Optional Analytics\n - Custom editor windows\n - Sample scenes and assets",
   "unity": "2020.3",


### PR DESCRIPTION
### Fixed
- glTFast symbol check ahead of package import removed.
- glTFast class type check to prevent define symbol add is removed.
- Settings asset creation in class with `InitializeOnLoad` attribute, refactored to create asset after asset indexing, using delayCall.
