### PR TITLE
[SDK-425] feat: display empty subdomain on quick start

### DIFF
--- a/Editor/UI/EditorWindows/SetupGuide/SetupGuide.cs
+++ b/Editor/UI/EditorWindows/SetupGuide/SetupGuide.cs
@@ -46,13 +46,12 @@ namespace ReadyPlayerMe.Core.Editor
         public void CreateGUI()
         {
             visualTreeAsset.CloneTree(rootVisualElement);
+            InitializeFooter();
             panel = new[]
             {
                 InitializeSubdomainPanel(),
                 InitializeAnalyticsPanel()
             };
-
-            InitializeFooter();
             StartStateMachine();
         }
 
@@ -74,18 +73,28 @@ namespace ReadyPlayerMe.Core.Editor
             {
                 nextButton.SetEnabled(!string.IsNullOrEmpty(subdomain));
             };
-
-            subdomainPanel.Q<Toggle>(USE_DEMO_SUBDOMAIN_TOGGLE).RegisterValueChangedCallback(x =>
+            if (!ProjectPrefs.GetBool(USE_DEMO_SUBDOMAIN_TOGGLE))
+            {
+                subdomainTemplate.ClearSubdomain();
+                nextButton.SetEnabled(false);
+            }
+            var demoSubdomainToggle = subdomainPanel.Q<Toggle>(USE_DEMO_SUBDOMAIN_TOGGLE);
+            demoSubdomainToggle.value = ProjectPrefs.GetBool(USE_DEMO_SUBDOMAIN_TOGGLE);
+            demoSubdomainToggle.RegisterValueChangedCallback(x =>
             {
                 if (x.newValue)
                 {
                     subdomainTemplate.SetDefaultSubdomain();
                     subdomainTemplate.SetFieldEnabled(false);
                     nextButton.SetEnabled(true);
+                    ProjectPrefs.SetBool(USE_DEMO_SUBDOMAIN_TOGGLE, true);
                 }
                 else
                 {
+                    subdomainTemplate.ClearSubdomain();
                     subdomainTemplate.SetFieldEnabled(true);
+                    nextButton.SetEnabled(false);
+                    ProjectPrefs.SetBool(USE_DEMO_SUBDOMAIN_TOGGLE, false);
                 }
             });
 
@@ -96,7 +105,6 @@ namespace ReadyPlayerMe.Core.Editor
         {
             var analyticsPanel = rootVisualElement.Q<VisualElement>(ANALYTICS_PANEL);
             analyticsPanel.style.display = new StyleEnum<DisplayStyle>(DisplayStyle.None);
-
             analyticsPanel.Q<Label>("PrivacyUrl").RegisterCallback<MouseUpEvent>(x =>
             {
                 Application.OpenURL(ANALYTICS_PRIVACY_URL);
@@ -123,7 +131,6 @@ namespace ReadyPlayerMe.Core.Editor
         {
             nextButton = rootVisualElement.Q<Button>(NEXT_BUTTON);
             nextButton.clicked += NextPanel;
-
             backButton = rootVisualElement.Q<Button>(BACK_BUTTON);
             backButton.clicked += PreviousPanel;
 
@@ -134,7 +141,6 @@ namespace ReadyPlayerMe.Core.Editor
                 IntegrationGuide.ShowWindow();
             };
         }
-
 
         private void PreviousPanel()
         {
@@ -168,7 +174,6 @@ namespace ReadyPlayerMe.Core.Editor
                     break;
             }
         }
-
 
         private void StartStateMachine()
         {

--- a/Editor/UI/EditorWindows/SetupGuide/SetupGuide.cs
+++ b/Editor/UI/EditorWindows/SetupGuide/SetupGuide.cs
@@ -1,4 +1,5 @@
 using ReadyPlayerMe.Core.Analytics;
+using ReadyPlayerMe.Core.Data;
 using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine;
@@ -73,13 +74,14 @@ namespace ReadyPlayerMe.Core.Editor
             {
                 nextButton.SetEnabled(!string.IsNullOrEmpty(subdomain));
             };
-            if (!ProjectPrefs.GetBool(USE_DEMO_SUBDOMAIN_TOGGLE))
+            if (!ProjectPrefs.GetBool(USE_DEMO_SUBDOMAIN_TOGGLE) && CoreSettingsHandler.CoreSettings.Subdomain == CoreSettings.DEFAULT_SUBDOMAIN)
             {
                 subdomainTemplate.ClearSubdomain();
                 nextButton.SetEnabled(false);
             }
             var demoSubdomainToggle = subdomainPanel.Q<Toggle>(USE_DEMO_SUBDOMAIN_TOGGLE);
             demoSubdomainToggle.value = ProjectPrefs.GetBool(USE_DEMO_SUBDOMAIN_TOGGLE);
+            subdomainTemplate.SetFieldEnabled(!ProjectPrefs.GetBool(USE_DEMO_SUBDOMAIN_TOGGLE));
             demoSubdomainToggle.RegisterValueChangedCallback(x =>
             {
                 if (x.newValue)

--- a/Editor/UI/EditorWindows/Templates/SubdomainTemplate.cs
+++ b/Editor/UI/EditorWindows/Templates/SubdomainTemplate.cs
@@ -51,8 +51,14 @@ namespace ReadyPlayerMe.Core.Editor
         public void SetDefaultSubdomain()
         {
             partnerSubdomain = CoreSettings.DEFAULT_SUBDOMAIN;
-            subdomainField.SetValueWithoutNotify(partnerSubdomain);
+            subdomainField.value = partnerSubdomain;
             SaveSubdomain();
+        }
+
+        public void ClearSubdomain()
+        {
+            partnerSubdomain = "";
+            subdomainField.value = partnerSubdomain;
         }
 
         public void SetFieldEnabled(bool enabled)
@@ -74,7 +80,7 @@ namespace ReadyPlayerMe.Core.Editor
 
         private void OnSubdomainFocusOut(FocusOutEvent _)
         {
-            if (ValidateSubdomain())
+            if (IsValidSubdomain())
             {
                 SaveSubdomain();
             }
@@ -85,7 +91,8 @@ namespace ReadyPlayerMe.Core.Editor
             return changeEvent =>
             {
                 partnerSubdomain = ExtractSubdomain(changeEvent.newValue);
-                errorIcon.visible = !ValidateSubdomain();
+                errorIcon.visible = !IsValidSubdomain();
+                if (changeEvent.previousValue == partnerSubdomain) return;
                 subdomainField.SetValueWithoutNotify(partnerSubdomain);
                 OnSubdomainChanged?.Invoke(partnerSubdomain);
             };
@@ -105,7 +112,7 @@ namespace ReadyPlayerMe.Core.Editor
             return url;
         }
 
-        private bool ValidateSubdomain()
+        private bool IsValidSubdomain()
         {
             return !partnerSubdomain.All(char.IsWhiteSpace) && !partnerSubdomain.Contains('/') && !EditorUtilities.IsUrlShortcodeValid(partnerSubdomain);
         }
@@ -114,11 +121,8 @@ namespace ReadyPlayerMe.Core.Editor
         {
             EditorPrefs.SetString(WEB_VIEW_PARTNER_SAVE_KEY, partnerSubdomain);
             var subDomain = CoreSettingsHandler.CoreSettings.Subdomain;
-            if (subDomain != partnerSubdomain)
-            {
-                AnalyticsEditorLogger.EventLogger.LogUpdatePartnerURL(subDomain, partnerSubdomain);
-            }
-
+            if (subDomain == partnerSubdomain || !IsValidSubdomain()) return;
+            AnalyticsEditorLogger.EventLogger.LogUpdatePartnerURL(subDomain, partnerSubdomain);
             CoreSettingsHandler.SaveSubDomain(partnerSubdomain);
         }
     }

--- a/Editor/UI/EditorWindows/Templates/SubdomainTemplate.cs
+++ b/Editor/UI/EditorWindows/Templates/SubdomainTemplate.cs
@@ -42,8 +42,6 @@ namespace ReadyPlayerMe.Core.Editor
 
             this.Q<Button>("SubdomainHelpButton").clicked += OnSubdomainHelpClicked;
 
-            errorIcon.RegisterCallback<MouseUpEvent>(OnErrorIconClicked);
-
             subdomainField.RegisterValueChangedCallback(SubdomainChanged(errorIcon));
             subdomainField.RegisterCallback<FocusOutEvent>(OnSubdomainFocusOut);
         }
@@ -71,11 +69,6 @@ namespace ReadyPlayerMe.Core.Editor
         {
             AnalyticsEditorLogger.EventLogger.LogFindOutMore(HelpSubject.Subdomain);
             Application.OpenURL(Constants.Links.DOCS_PARTNERS_LINK);
-        }
-
-        private void OnErrorIconClicked(MouseUpEvent _)
-        {
-            Application.OpenURL(Constants.Links.DOCS_QUICKSTART_LINK);
         }
 
         private void OnSubdomainFocusOut(FocusOutEvent _)

--- a/Editor/UI/Obsolete/Components/SubdomainField.cs
+++ b/Editor/UI/Obsolete/Components/SubdomainField.cs
@@ -61,7 +61,7 @@ namespace ReadyPlayerMe.Core.Editor
                 EditorGUILayout.LabelField(".readyplayer.me", textLabelStyle, GUILayout.Width(102), GUILayout.Height(20));
                 var button = new GUIContent(errorIcon, DOMAIN_VALIDATION_ERROR);
 
-                var isSubdomainValid = ValidateSubdomain();
+                var isSubdomainValid = IsValidSubdomain();
 
                 if (!isSubdomainValid)
                 {
@@ -109,7 +109,7 @@ namespace ReadyPlayerMe.Core.Editor
             errorButtonStyle.margin = new RectOffset(0, 0, 2, 2);
         }
 
-        private bool ValidateSubdomain()
+        private bool IsValidSubdomain()
         {
             return !partnerSubdomain.All(char.IsWhiteSpace) && !partnerSubdomain.Contains('/') && !EditorUtilities.IsUrlShortcodeValid(partnerSubdomain);
         }
@@ -139,11 +139,8 @@ namespace ReadyPlayerMe.Core.Editor
         {
             EditorPrefs.SetString(WEB_VIEW_PARTNER_SAVE_KEY, partnerSubdomain);
             var subDomain = CoreSettingsHandler.CoreSettings.Subdomain;
-            if (subDomain != partnerSubdomain)
-            {
-                AnalyticsEditorLogger.EventLogger.LogUpdatePartnerURL(subDomain, partnerSubdomain);
-            }
-
+            if (subDomain == partnerSubdomain || !IsValidSubdomain()) return;
+            AnalyticsEditorLogger.EventLogger.LogUpdatePartnerURL(subDomain, partnerSubdomain);
             CoreSettingsHandler.SaveSubDomain(partnerSubdomain);
         }
     }

--- a/Runtime/CoreSettingsHandler.cs
+++ b/Runtime/CoreSettingsHandler.cs
@@ -33,6 +33,7 @@ namespace ReadyPlayerMe.Core
 #if UNITY_EDITOR
         public static void SaveSubDomain(string subDomain)
         {
+            if (string.IsNullOrEmpty(subDomain) || coreSettings.Subdomain == subDomain) return;
             coreSettings.Subdomain = subDomain;
             Save();
         }


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-425](https://ready-player-me.atlassian.net/browse/[SDK-425])

## Description

- this PR includes changes to the setup guide window. It will now default to an empty subdomain field and prevent clicking next unless they enter subdomain OR click the "I don't have an account..." toggle instead
- if users close this window without doing anything it will be in the same state next open (still empty)
- conversely if you do enable the "I don't have an account.." toggle it will remember that next time you open the window. 

![image](https://github.com/readyplayerme/rpm-unity-sdk-core/assets/7085672/4ab95a3b-dc2d-40e6-9f58-f98d93a7c775)


<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   Import the branch in a new project and observe the setup guide popup
- Subdomain field should be empty and display error icon next to it
- next button should be disabled (preventing progression to next screen)
- the "I don't have an account..." toggle should be unchecked by default
- If you close the window without doing anything else it should be in the same state if you reopen it

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-425]: https://ready-player-me.atlassian.net/browse/SDK-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-425]: https://ready-player-me.atlassian.net/browse/SDK-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ