### PR TITLE
[SDK-544] feat: update context menu ordering to add separators

### DIFF
--- a/Editor/Module Management/ModuleUpdater.cs
+++ b/Editor/Module Management/ModuleUpdater.cs
@@ -43,7 +43,6 @@ namespace ReadyPlayerMe.Core.Editor
 
         private const string AVATAR_LOADER_PACKAGE = "com.readyplayerme.avatarloader";
 
-
         static ModuleUpdater()
         {
             EntryPoint.Startup += () => Check(true);
@@ -52,7 +51,7 @@ namespace ReadyPlayerMe.Core.Editor
         /// <summary>
         /// Check for Ready Player Me package updates.
         /// </summary>
-        [MenuItem("Ready Player Me/Check For Updates")]
+        [MenuItem("Ready Player Me/Check For Updates", priority = 23)]
         public static void CheckForUpdates()
         {
             AnalyticsEditorLogger.EventLogger.LogCheckForUpdates();
@@ -80,7 +79,6 @@ namespace ReadyPlayerMe.Core.Editor
                 var releasesUrl = repoUrl
                     .Split(new[] { ".git" }, StringSplitOptions.None)[0]
                     .Replace(GITHUB_WEBSITE, GITHUB_API_URL) + "/releases";
-
 
                 var packageUrl = repoUrl.Split('#')[0];
 

--- a/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
+++ b/Editor/UI/EditorWindows/AvatarLoaderEditor/AvatarLoaderEditor.cs
@@ -25,7 +25,7 @@ namespace ReadyPlayerMe.Core.Editor
         private bool useEyeAnimations;
         private bool useVoiceToAnim;
 
-        [MenuItem("Ready Player Me/Avatar Loader", priority = 0)]
+        [MenuItem("Ready Player Me/Avatar Loader", priority = 1)]
         public static void ShowWindow()
         {
 #if !GLTFAST

--- a/Editor/UI/EditorWindows/IntegrationGuide/IntegrationGuide.cs
+++ b/Editor/UI/EditorWindows/IntegrationGuide/IntegrationGuide.cs
@@ -21,7 +21,7 @@ namespace ReadyPlayerMe.Core.Editor
 
         [SerializeField] private VisualTreeAsset visualTreeAsset;
 
-        [MenuItem("Ready Player Me/Integration Guide")]
+        [MenuItem("Ready Player Me/Integration Guide", priority = 12)]
         public static void ShowWindow()
         {
             var window = GetWindow<IntegrationGuide>();

--- a/Editor/UI/EditorWindows/SetupGuide/SetupGuide.cs
+++ b/Editor/UI/EditorWindows/SetupGuide/SetupGuide.cs
@@ -35,7 +35,7 @@ namespace ReadyPlayerMe.Core.Editor
         private Button finishSetupButton;
         private Button openQuickStartButton;
 
-        [MenuItem("Ready Player Me/Setup Guide")]
+        [MenuItem("Ready Player Me/Setup Guide", priority = 12)]
         public static void ShowWindow()
         {
             var window = GetWindow<SetupGuide>();


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-544](https://ready-player-me.atlassian.net/browse/SDK-544)

## Description

-  update menu item priority for better separation
- also moved the Unity-SDK only menu items (internal dev functions) into a separate RPM Tools section. This enables us to cleanup Ready Player Me section and also see exactly what developers would see after importing the package into a project

![Screenshot 2023-10-10 082817](https://github.com/readyplayerme/rpm-unity-sdk-netcode-support/assets/7085672/873fb049-5ffc-4798-8778-90b0d6fc3704)

![Screenshot 2023-10-10 082813](https://github.com/readyplayerme/rpm-unity-sdk-core/assets/7085672/e7721ac7-5582-4aa8-b1d1-a0040be23c83)


<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   Add steps to locally test these changes

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-544]: https://ready-player-me.atlassian.net/browse/SDK-544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ