### PR TITLE
[SDK-704] feat: fix pasted text display issue

### DIFF
--- a/Editor/UI/EditorWindows/Templates/SubdomainTemplate.cs
+++ b/Editor/UI/EditorWindows/Templates/SubdomainTemplate.cs
@@ -87,6 +87,7 @@ namespace ReadyPlayerMe.Core.Editor
                 errorIcon.visible = !IsValidSubdomain();
                 if (changeEvent.previousValue == partnerSubdomain) return;
                 subdomainField.SetValueWithoutNotify(partnerSubdomain);
+                subdomainField.Focus(); // forces text to resize, making new subdomain value visible
                 OnSubdomainChanged?.Invoke(partnerSubdomain);
             };
         }


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-704](https://ready-player-me.atlassian.net/browse/SDK-704)

## Description

-   now when you paste subdomain `https://kangarudev.readyplayer.me?frameApi` into subdomain field it will correctly resize the text field so that the subdomain is visible. 
![image](https://github.com/readyplayerme/rpm-unity-sdk-core/assets/7085672/4eb7841e-25b0-4e44-84b7-165e12e45415)


<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   Add steps to locally test these changes

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-704]: https://ready-player-me.atlassian.net/browse/SDK-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ