### PR TITLE
feat: don't save, when avatar is not in draft

### DIFF
--- a/Runtime/AvatarCreator/Scripts/Data/AvatarProperties.cs
+++ b/Runtime/AvatarCreator/Scripts/Data/AvatarProperties.cs
@@ -17,5 +17,6 @@ namespace ReadyPlayerMe.AvatarCreator
         [JsonConverter(typeof(CategoryDictionaryConverter))]
         public Dictionary<AssetType, object> Assets;
         public string Base64Image;
+        public bool isDraft;
     }
 }

--- a/Runtime/AvatarCreator/Scripts/Managers/AvatarManager.cs
+++ b/Runtime/AvatarCreator/Scripts/Managers/AvatarManager.cs
@@ -88,7 +88,7 @@ namespace ReadyPlayerMe.AvatarCreator
                 {
                     return (null, avatarProperties);
                 }
-
+                avatarProperties.isDraft = true;
                 avatarId = avatarProperties.Id;
                 avatar = await GetAvatar(avatarId, bodyType, true);
             }

--- a/Runtime/Core/Scripts/Utils/WebRequestDispatcher.cs
+++ b/Runtime/Core/Scripts/Utils/WebRequestDispatcher.cs
@@ -84,7 +84,7 @@ namespace ReadyPlayerMe.Core
                 {
                     return response;
                 }
-                Debug.Log(request.downloadHandler.text + "\n" + url);
+                Debug.Log(request.downloadHandler.text + "\n" + request.method.ToUpper() + " " + url);
                 return response;
             }
 

--- a/Samples~/AvatarCreatorSamples/LegacyAvatarCreator/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/AvatarCreatorSamples/LegacyAvatarCreator/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -249,9 +249,13 @@ namespace ReadyPlayerMe
         private async void Save()
         {
             var startTime = Time.time;
+
             LoadingManager.EnableLoading("Saving avatar...", LoadingManager.LoadingType.Popup);
-            var avatarId = await avatarManager.Save();
-            AvatarCreatorData.AvatarProperties.Id = avatarId;
+            if (AvatarCreatorData.AvatarProperties.isDraft)
+            {
+                var avatarId = await avatarManager.Save();
+                AvatarCreatorData.AvatarProperties.Id = avatarId;
+            }
             StateMachine.SetState(StateType.End);
             LoadingManager.DisableLoading();
             SDKLogger.Log(TAG, $"Avatar saved in {Time.time - startTime:F2}s");
@@ -286,7 +290,7 @@ namespace ReadyPlayerMe
             {
                 return;
             }
-
+            AvatarCreatorData.AvatarProperties.isDraft = true;
             ProcessAvatar(avatar);
             Destroy(currentAvatar);
             currentAvatar = avatar;


### PR DESCRIPTION
## [SDK-401](https://ready-player-me.atlassian.net/browse/SDK-401)

## Description

-  When there is no draft avatar, then don't save the avatar.

## How to Test

-   Try to go over the old avatar creator with an update on the avatar (change some assets) and without changing and verify, that the avatar is successfully loaded in both cases.





[SDK-401]: https://ready-player-me.atlassian.net/browse/SDK-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ