### PR TITLE
feat: add rpm-source header to the requests

### DIFF
--- a/Runtime/Core/Scripts/CommonHeaders.cs
+++ b/Runtime/Core/Scripts/CommonHeaders.cs
@@ -24,11 +24,17 @@ namespace ReadyPlayerMe.Core
             return new KeyValuePair<string, string>("X-APP-ID", CoreSettingsHandler.CoreSettings.AppId);
         }
 
+        public static KeyValuePair<string, string> GetAppSource()
+        {
+            return new KeyValuePair<string, string>("rpm-source", UNITY_PREFIX);
+        }
+
         public static IDictionary<string, string> GetHeadersWithAppId()
         {
-            IDictionary<string,string> dictionary = new Dictionary<string, string>();
+            IDictionary<string, string> dictionary = new Dictionary<string, string>();
             dictionary.Add(GetApplicationJsonHeader());
             dictionary.Add(GetAppIdHeader());
+            dictionary.Add(GetAppSource());
             return dictionary;
         }
 


### PR DESCRIPTION
## [SDK-627](https://ready-player-me.atlassian.net/browse/SDK-627)

## Description

-   Add rpm-source header to the requests. This is used to track the usage of avatar creator.

## How to Test

-   Right now save draft endpoint processes this data. Check, that if you save the draft in the avatar creator, that in amplitude, there will be one extra entry. (This is cached for 12 hours, so you can make only one request)





[SDK-627]: https://ready-player-me.atlassian.net/browse/SDK-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ