### PR TITLE
feat: delete draft avatar, when the new avatar is loaded for update

### DIFF
--- a/Runtime/AvatarCreator/Scripts/Managers/AvatarManager.cs
+++ b/Runtime/AvatarCreator/Scripts/Managers/AvatarManager.cs
@@ -253,7 +253,7 @@ namespace ReadyPlayerMe.AvatarCreator
         /// <summary>
         /// This will delete the avatar draft which have not been saved. 
         /// </summary>
-        public async void Delete(bool isDraft)
+        public async Task Delete(bool isDraft)
         {
             try
             {

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -22,7 +22,6 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
         [SerializeField] private AvatarConfig inCreatorConfig;
         [SerializeField] private RuntimeAnimatorController animator;
         [SerializeField] private AccountCreationElement accountCreationElement;
-
         private PartnerAssetsManager partnerAssetManager;
         private AvatarManager avatarManager;
 
@@ -119,6 +118,11 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
 
         private void OnErrorCallback(string error)
         {
+            if (error.Equals("Avatar draft not found"))
+            {
+                return;
+            }
+
             SDKLogger.Log(TAG, $"An error occured: {error}");
             avatarManager.OnError -= OnErrorCallback;
             partnerAssetManager.OnError -= OnErrorCallback;
@@ -282,6 +286,11 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
             {
                 Assets = new Dictionary<AssetType, object>()
             };
+
+            if (!AvatarCreatorData.AvatarProperties.isDraft)
+            {
+                await avatarManager.Delete(true);
+            }
 
             payload.Assets.Add(category, assetId);
             lastRotation = currentAvatar.transform.rotation;

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -287,14 +287,17 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
                 Assets = new Dictionary<AssetType, object>()
             };
 
+
+
+            payload.Assets.Add(category, assetId);
+            lastRotation = currentAvatar.transform.rotation;
+            LoadingManager.EnableLoading(UPDATING_YOUR_AVATAR_LOADING_TEXT, LoadingManager.LoadingType.Popup);
+
             if (!AvatarCreatorData.AvatarProperties.isDraft)
             {
                 await avatarManager.Delete(true);
             }
 
-            payload.Assets.Add(category, assetId);
-            lastRotation = currentAvatar.transform.rotation;
-            LoadingManager.EnableLoading(UPDATING_YOUR_AVATAR_LOADING_TEXT, LoadingManager.LoadingType.Popup);
             var avatar = await avatarManager.UpdateAsset(category, AvatarCreatorData.AvatarProperties.BodyType, assetId);
             if (avatar == null)
             {


### PR DESCRIPTION
## [SDK-182](https://ready-player-me.atlassian.net/browse/SDK-182)

## Description

-   Delete the draft avatar, if it exists before editing


## How to Test

- Log into your RPM account  
- Click on the Configure in the avatar in the avatar creator, edit something, and close the play mode
- play again
- Check, that when customizing the avatar, the previous changes are not visible.






[SDK-182]: https://ready-player-me.atlassian.net/browse/SDK-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ