### PR TITLE
Hotfix/6.0.1

### DIFF
--- a/.github/latest.md
+++ b/.github/latest.md
@@ -3,23 +3,4 @@
 
 ### Updated
 
-- **BREAKING: Renamed Avatar Create Samples** [#210](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/210) _This change
-  may require updates to existing references in your projects._
-- Small fix for button icon resizing [#215](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/215)
-- LoginWithCode can now merge avatars into RPM account [#219](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/219)
-- Recover hair when headwear is removed [#224](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/224)
-- Added extra check to prevent settings override [#226](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/226)
-
-### Added
-
-- Logout Element for Avatar Creator [#216](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/216)
-- New iFrame Events to WebFrameHandler [#212](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/212)
-- Added support for XR Avatar skeleton [#217](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/217)
-- Added Avatar List element [#218](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/218)
-- Account creation and login elements in Avatar Creator sample [#230](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/230)
-
-### Removed
-
-- Quickstart Parameter from UrlConfig [#221](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/221)
-- Selfie to Avatar Element* [#220](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/220)
-- Removed WebView auto installation [#208](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/208)
+- updated default render settings to fix an issue causing incorrect halfbody avatar renders

--- a/.github/latest.md
+++ b/.github/latest.md
@@ -3,4 +3,4 @@
 
 ### Updated
 
-- updated default render settings to fix an issue causing incorrect halfbody avatar renders
+- updated default render settings to fix an issue causing incorrect halfbody avatar renders [#238](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/238)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Updated
 
-- updated default render settings to fix an issue causing incorrect halfbody avatar renders
+- updated default render settings to fix an issue causing incorrect halfbody avatar renders [#238](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/238)
 
 ## [6.0.0] - 2024.02.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [6.0.1] - 2024.02.22
+## [6.0.1] - 2024.02.26
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.0.1] - 2024.02.22
+
+### Updated
+
+- updated default render settings to fix an issue causing incorrect halfbody avatar renders
+
 ## [6.0.0] - 2024.02.19
 
 ### Updated

--- a/Runtime/Core/Scripts/Data/ApplicationData.cs
+++ b/Runtime/Core/Scripts/Data/ApplicationData.cs
@@ -6,7 +6,7 @@ namespace ReadyPlayerMe.Core
 {
     public static class ApplicationData
     {
-        public const string SDK_VERSION = "6.0.0";
+        public const string SDK_VERSION = "v6.0.1";
         private const string TAG = "ApplicationData";
         private const string DEFAULT_RENDER_PIPELINE = "Built-In Render Pipeline";
         private static readonly AppData Data;

--- a/Runtime/Core/Scripts/Data/AvatarRenderSettings.cs
+++ b/Runtime/Core/Scripts/Data/AvatarRenderSettings.cs
@@ -24,7 +24,7 @@ namespace ReadyPlayerMe.Core
     public class AvatarRenderSettings
     {
         public Expression Expression = Expression.None;
-        public RenderPose Pose = RenderPose.Relaxed;
+        public RenderPose Pose = RenderPose.None;
         public RenderCamera Camera = RenderCamera.Portrait;
         public int Quality = 100;
         public int Size = 800;
@@ -39,8 +39,10 @@ namespace ReadyPlayerMe.Core
             {
                 queryBuilder.AddKeyValue(nameof(Core.Expression).ToCamelCase(), Expression.ToString().ToCamelCase());
             }
-
-            queryBuilder.AddKeyValue(nameof(Pose).ToCamelCase(), RenderSettingsHelper.RenderPoseMap[Pose]);
+            if (Pose != RenderPose.None)
+            {
+                queryBuilder.AddKeyValue(nameof(Pose).ToCamelCase(), RenderSettingsHelper.RenderPoseMap[Pose]);
+            }
 
             if (BlendShapes != null)
             {

--- a/Runtime/Core/Scripts/Data/Enums.cs
+++ b/Runtime/Core/Scripts/Data/Enums.cs
@@ -113,6 +113,7 @@ namespace ReadyPlayerMe.Core
 
     public enum RenderPose
     {
+        None,
         Relaxed,
         PowerStance,
         Standing,

--- a/Runtime/Core/Scripts/Data/Enums.cs
+++ b/Runtime/Core/Scripts/Data/Enums.cs
@@ -111,6 +111,10 @@ namespace ReadyPlayerMe.Core
         Rage,
     }
 
+    /// <summary>
+    /// This enumeration describes the different types of render poses.
+    /// These poses are only supported for fullbody avatars, for halfbody avatars this should be set to None.
+    /// </summary>
     public enum RenderPose
     {
         None = -1,

--- a/Runtime/Core/Scripts/Data/Enums.cs
+++ b/Runtime/Core/Scripts/Data/Enums.cs
@@ -113,7 +113,7 @@ namespace ReadyPlayerMe.Core
 
     public enum RenderPose
     {
-        None,
+        None = -1,
         Relaxed,
         PowerStance,
         Standing,

--- a/Samples~/AvatarRenderSamples/MultipleRenders/MultipleAvatarRenderExample.unity
+++ b/Samples~/AvatarRenderSamples/MultipleRenders/MultipleAvatarRenderExample.unity
@@ -1553,37 +1553,97 @@ PrefabInstance:
     - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
         type: 3}
       propertyPath: renderSettings.BlendShapes.Array.size
-      value: 2
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
         type: 3}
       propertyPath: renderSettings.BlendShapes.Array.data[0].Name
-      value: eyesClosed
-      objectReference: {fileID: 0}
-    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
-        type: 3}
-      propertyPath: renderSettings.BlendShapes.Array.data[1].Name
       value: mouthOpen
       objectReference: {fileID: 0}
     - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
         type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[1].Name
+      value: mouthFunnel
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
       propertyPath: renderSettings.BlendShapes.Array.data[2].Name
-      value: jawOpen
+      value: eyeWideLeft
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[3].Name
+      value: eyeWideRight
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[4].Name
+      value: browInnerUp
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[5].Name
+      value: browOuterUpLeft
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[6].Name
+      value: browOuterUpRight
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[7].Name
+      value: mouthSmile
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[8].Name
+      value: browOuterUpLeft
       objectReference: {fileID: 0}
     - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
         type: 3}
       propertyPath: renderSettings.BlendShapes.Array.data[0].Value
-      value: 1
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
         type: 3}
       propertyPath: renderSettings.BlendShapes.Array.data[1].Value
-      value: 1
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
         type: 3}
       propertyPath: renderSettings.BlendShapes.Array.data[2].Value
-      value: 0.3
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[3].Value
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[4].Value
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[5].Value
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[6].Value
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[7].Value
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616518480041139177, guid: 86b528853dfd4214a8140eee1b7ed309,
+        type: 3}
+      propertyPath: renderSettings.BlendShapes.Array.data[8].Value
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 86b528853dfd4214a8140eee1b7ed309, type: 3}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.readyplayerme.core",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "displayName": "Ready Player Me Core",
   "description": "This Module contains all the core functionality required for using Ready Player Me avatars in Unity, including features such as: \n - Module management and automatic package setup logic\n - Avatar loading from .glb files \n - Avatar creation \n - Avatar and 2D render requests \n - Optional Analytics\n - Custom editor windows\n - Sample scenes and assets",
   "unity": "2020.3",


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.atlassian.net/browse/TICKETID)

## Description

-   this hotfix addresses an issue with the default render pose, causing incorrect renders of halfbody avatars
Halfbody avatars with default (and I assume other poses) resulted in this render 
![image](https://github.com/readyplayerme/rpm-unity-sdk-core/assets/7085672/9da6f204-a30b-47fa-be4c-2d100e7eeace)

I also updated the blendshapes values on the blendshapes render in the example as the other old didn't look very good :D 
![image](https://github.com/readyplayerme/rpm-unity-sdk-core/assets/7085672/0e05229d-c116-4e8f-b38a-ba8f495e9732)


<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   Add steps to locally test these changes

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



