### PR TITLE
GetHeadMeshes method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## [6.0.2] - 2024.MM.DD
+
+### Updated
+- AvatarMeshHelper now supports multiple mesh and material transfer. [#241](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/241)
+
 ## [6.0.1] - 2024.02.26
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 - AvatarMeshHelper now supports multiple mesh and material transfer. [#241](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/241)
 
+### Added
+- GetHeadMeshes method to AvatarMeshHelper to get head related meshes from an avatar. [#242](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/242)
+
 ## [6.0.1] - 2024.02.26
 
 ### Updated

--- a/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
+++ b/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
@@ -1,10 +1,24 @@
+using System;
 using UnityEngine;
+using System.Linq;
 using System.Collections.Generic;
+using Object = UnityEngine.Object;
 
 namespace ReadyPlayerMe.Core
 {
     public static class AvatarMeshHelper
     {
+        private static readonly string[] headMeshNames = {
+            "Renderer_Head",
+            "Renderer_Hair",
+            "Renderer_Teeth",
+            "Renderer_Glasses",
+            "Renderer_EyeLeft",
+            "Renderer_EyeRight",
+            "Renderer_Headwear",
+            "Renderer_Facewear",
+        };
+
         [Obsolete("Use TransferMesh(GameObject source, GameObject target) instead.")]
         public static void TransferMesh(GameObject source, SkinnedMeshRenderer[] targetMeshes, Animator targetAnimator)
         {
@@ -63,6 +77,27 @@ namespace ReadyPlayerMe.Core
             var sourceAnimator = source.GetComponentInChildren<Animator>();
             var targetAnimator = target.GetComponentInChildren<Animator>();
             targetAnimator.avatar = sourceAnimator.avatar;
+        }
+        
+        /// <summary>
+        ///     Returns the meshes of the head of the avatar, such as glasses, hair, teeth, etc.
+        /// </summary>
+        /// <param name="avatar">A Ready Player Me Avatar.</param>
+        /// <returns>Head meshes in a GameObject Array.</returns>
+        public static GameObject[] GetHeadMeshes(GameObject avatar)
+        {
+            var renderers = avatar.GetComponentsInChildren<SkinnedMeshRenderer>();
+            var headMeshes = new List<GameObject>();
+            
+            foreach (var renderer in renderers)
+            {
+                if (headMeshNames.Contains(renderer.name))
+                {
+                    headMeshes.Add(renderer.gameObject);
+                }
+            }
+            
+            return headMeshes.ToArray();
         }
     }
 }

--- a/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
+++ b/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
@@ -5,6 +5,12 @@ namespace ReadyPlayerMe.Core
 {
     public static class AvatarMeshHelper
     {
+        [Obsolete("Use TransferMesh(GameObject source, GameObject target) instead.")]
+        public static void TransferMesh(GameObject source, SkinnedMeshRenderer[] targetMeshes, Animator targetAnimator)
+        {
+            TransferMesh(source, targetMeshes[0].transform.parent.gameObject);
+        }
+        
         /// <summary>
         ///     Transfers the mesh and material data from the source to the target avatar.
         /// </summary>

--- a/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
+++ b/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
@@ -13,29 +13,28 @@ namespace ReadyPlayerMe.Core
         public static void TransferMesh(GameObject source, GameObject target)
         {
             // store the relevant data of the source (downloaded) avatar
-            var dataDict = new Dictionary<string, (Material, Mesh, Transform[])>();
+            var rendererDict = new Dictionary<string, SkinnedMeshRenderer>();
             
             var sourceRenderers = source.GetComponentsInChildren<SkinnedMeshRenderer>();
             var targetRenderers = target.GetComponentsInChildren<SkinnedMeshRenderer>();
             
             foreach (var renderer in sourceRenderers)
             {
-                dataDict.Add(renderer.name, (renderer.materials[0], renderer.sharedMesh, renderer.bones));
+                rendererDict.Add(renderer.name, renderer);
             }
             
             // transfer the data to the target skinning mesh renderers
             foreach (var renderer in targetRenderers)
             {
-                if (dataDict.TryGetValue(renderer.name, out var data))
+                if (rendererDict.TryGetValue(renderer.name, out var sourceRenderer))
                 {
-                    var (sourceMaterial, sourceMesh, sourceBones) = data;
-                    renderer.material = sourceMaterial;
-                    renderer.sharedMesh = sourceMesh;
+                    renderer.material = sourceRenderer.materials[0];
+                    renderer.sharedMesh = sourceRenderer.sharedMesh;
                     
                     // transfer the bone data
                     foreach (var targetBone in renderer.bones)
                     {
-                        foreach (var sourceBone in sourceBones)
+                        foreach (var sourceBone in sourceRenderer.bones)
                         {
                             if (sourceBone.name == targetBone.name)
                             {

--- a/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
+++ b/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
@@ -66,11 +66,6 @@ namespace ReadyPlayerMe.Core
                         }
                     }
                 }
-                else
-                {
-                    // remove the renderer if it's not found in the source avatar
-                    Object.Destroy(renderer.gameObject);
-                }
             }
             
             // transfer the animation avatar

--- a/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
+++ b/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
@@ -66,6 +66,11 @@ namespace ReadyPlayerMe.Core
                         }
                     }
                 }
+                else
+                {
+                    renderer.sharedMesh = null;
+                    renderer.material = null;
+                }
             }
             
             // transfer the animation avatar

--- a/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
+++ b/Runtime/Core/Scripts/Utils/AvatarMeshHelper.cs
@@ -1,29 +1,63 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace ReadyPlayerMe.Core
 {
     public static class AvatarMeshHelper
     {
-        public static void TransferMesh(GameObject source, SkinnedMeshRenderer[] targetMeshes, Animator targetAnimator)
+        /// <summary>
+        ///     Transfers the mesh and material data from the source to the target avatar.
+        /// </summary>
+        /// <param name="source">Imported Ready Player Me avatar.</param>
+        /// <param name="target">Photon Network Player Character.</param>
+        public static void TransferMesh(GameObject source, GameObject target)
         {
-            var sourceAnimator = source.GetComponentInChildren<Animator>();
-            SkinnedMeshRenderer[] sourceMeshes = source.GetComponentsInChildren<SkinnedMeshRenderer>();
-            for (var i = 0; i < targetMeshes.Length; i++)
+            // store the relevant data of the source (downloaded) avatar
+            var dataDict = new Dictionary<string, (Material, Mesh, Transform[])>();
+            
+            var sourceRenderers = source.GetComponentsInChildren<SkinnedMeshRenderer>();
+            var targetRenderers = target.GetComponentsInChildren<SkinnedMeshRenderer>();
+            
+            foreach (var renderer in sourceRenderers)
             {
-                if (i >= sourceMeshes.Length)
-                {
-                    targetMeshes[i].enabled = false;
-                    break;
-                }
-                Mesh mesh = sourceMeshes[i].sharedMesh;
-                targetMeshes[i].sharedMesh = mesh;
-                targetMeshes[i].enabled = true;
-                Material[] materials = sourceMeshes[i].sharedMaterials;
-                targetMeshes[i].sharedMaterials = materials;
+                dataDict.Add(renderer.name, (renderer.materials[0], renderer.sharedMesh, renderer.bones));
             }
-
-            Avatar avatar = sourceAnimator.avatar;
-            targetAnimator.avatar = avatar;
+            
+            // transfer the data to the target skinning mesh renderers
+            foreach (var renderer in targetRenderers)
+            {
+                if (dataDict.TryGetValue(renderer.name, out var data))
+                {
+                    var (sourceMaterial, sourceMesh, sourceBones) = data;
+                    renderer.material = sourceMaterial;
+                    renderer.sharedMesh = sourceMesh;
+                    
+                    // transfer the bone data
+                    foreach (var targetBone in renderer.bones)
+                    {
+                        foreach (var sourceBone in sourceBones)
+                        {
+                            if (sourceBone.name == targetBone.name)
+                            {
+                                targetBone.position = sourceBone.position;
+                                targetBone.rotation = sourceBone.rotation;
+                                targetBone.localScale = sourceBone.localScale;
+                                break;                            
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    // remove the renderer if it's not found in the source avatar
+                    Object.Destroy(renderer.gameObject);
+                }
+            }
+            
+            // transfer the animation avatar
+            var sourceAnimator = source.GetComponentInChildren<Animator>();
+            var targetAnimator = target.GetComponentInChildren<Animator>();
+            targetAnimator.avatar = sourceAnimator.avatar;
         }
     }
 }

--- a/Tests/Editor/AvatarRenderLoaderTests.cs
+++ b/Tests/Editor/AvatarRenderLoaderTests.cs
@@ -10,7 +10,7 @@ namespace ReadyPlayerMe.Core.Tests
         private const RenderCamera RENDER_SCENE = RenderCamera.FullBody;
         private const string RENDER_BLENDSHAPE = "mouthSmile";
         private const float BLENDSHAPE_VALUE = 0.5f;
-        private const string RENDER_STRING = "pose=relaxed&blendShapes[mouthSmile]=0.5&camera=portrait&size=800&background=255,255,255";
+        private const string RENDER_STRING = "blendShapes[mouthSmile]=0.5&camera=portrait&size=800&background=255,255,255";
 
         [Test]
         public async Task RenderLoader_Load()


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.atlassian.net/browse/TICKETID)

## Description

- GetHeadMeshes method helps developers get the list of game objects that are related to avatars head, which can be useful for hiding these in certain situations.
- Removed logic for removing unused meshes to avoid missing customizations upon next use.

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   Load a non-atlassed avatar and call the method avatar as it's only parameter.

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [x] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



