### PR TITLE
Add Exception Handling for Unknown Errors

### DIFF
--- a/Runtime/Core/Scripts/AvatarObjectLoader.cs
+++ b/Runtime/Core/Scripts/AvatarObjectLoader.cs
@@ -144,6 +144,11 @@ namespace ReadyPlayerMe.Core
                 Failed(executor.IsCancelled ? FailureType.OperationCancelled : exception.FailureType, exception.Message);
                 return;
             }
+            catch (Exception e)
+            {
+                Failed(FailureType.Unknown, e.Message);
+                return;
+            }
 
             var avatar = (GameObject) context.Data;
             avatar.SetActive(true);

--- a/Runtime/Core/Scripts/Data/Enums.cs
+++ b/Runtime/Core/Scripts/Data/Enums.cs
@@ -98,7 +98,8 @@ namespace ReadyPlayerMe.Core
         DirectoryAccessError,
         AvatarProcessError,
         AvatarRenderError,
-        OperationCancelled
+        OperationCancelled,
+        Unknown
     }
 
     public enum Expression


### PR DESCRIPTION
## Description
This PR addresses a critical issue identified in the Unity SDK, as discussed in the forum post at [ReadyPlayer.Me Unity SDK Bug Report](https://forum.readyplayer.me/t/unity-sdk-bug-report/149).

The core of the problem lies within the exception handling mechanism of the `Load(string url)` method in the `AvatarObjectLoader` class. Currently, if an exception occurs that is not of type `CustomException`, it goes unhandled. Consequently, this unhandled exception results in the calling function indefinitely waiting for the task to complete, leading to a deadlock situation.

## Steps to Reproduce the Issue
The issue can be consistently reproduced in the Unity editor by attempting to load the same avatar multiple times through the SDK. This action triggers a system exception due to a file creation failure, as demonstrated by the following error message:

```
Avatar load failed: Failed to create file C:/.../Assets/Ready Player Me/Avatars/65feb632f66d96389db23a5e/4fdc155cfca95a621bf54cc1b7b28ea6/65feb632f66d96389db23a5e.glb. Url https://models.readyplayer.me/65feb632f66d96389db23a5e.glb
```

## Proposed Solution
To address this issue, the proposed solution involves enhancing the exception handling mechanism within the `Load(string url)` method. Specifically, the modification extends the existing catch block to also catch any `System.Exception` instances. Upon catching such an exception, the method will then invoke a failure callback with an error type of `CustomException.Unknown`. This approach ensures that no exceptions are left unhandled, thereby preventing the calling function from hanging indefinitely.












