### PR TITLE
[SDK-926] feat: added optional parameter to filter meshes

### DIFF
--- a/Runtime/Core/Scripts/Animation/EyeAnimationHandler.cs
+++ b/Runtime/Core/Scripts/Animation/EyeAnimationHandler.cs
@@ -81,7 +81,7 @@ namespace ReadyPlayerMe.Core
         /// </summary>
         private void Awake()
         {
-            headMesh = gameObject.GetMeshRenderer(MeshType.HeadMesh);
+            UpdateHeadMesh();
             hasBlinkBlendShapes = HasBlinkBlendshapes();
             ValidateSkeleton();
 
@@ -99,6 +99,11 @@ namespace ReadyPlayerMe.Core
                 Reset();
                 enabled = false;
             }
+        }
+
+        public void UpdateHeadMesh()
+        {
+            headMesh = gameObject.GetMeshRenderer(MeshType.HeadMesh, true);
         }
 
         private bool HasBlinkBlendshapes()

--- a/Runtime/Core/Scripts/Extensions/ExtensionMethods.cs
+++ b/Runtime/Core/Scripts/Extensions/ExtensionMethods.cs
@@ -56,12 +56,16 @@ namespace ReadyPlayerMe.Core
         /// </summary>
         /// <param name="gameObject">The <see cref="GameObject" /> to search for a <see cref="SkinnedMeshRenderer" />.</param>
         /// <param name="meshType">Determines the <see cref="MeshType" /> to search for.</param>
+        /// <param name="ignoreNullMesh">If true it will filter our <see cref="SkinnedMeshRenderers"/> with NO mesh data.</param>
         /// <returns>The <see cref="SkinnedMeshRenderer" /> if found.</returns>
-        public static SkinnedMeshRenderer GetMeshRenderer(this GameObject gameObject, MeshType meshType)
+        public static SkinnedMeshRenderer GetMeshRenderer(this GameObject gameObject, MeshType meshType, bool ignoreNullMesh = false)
         {
             SkinnedMeshRenderer mesh;
-            List<SkinnedMeshRenderer> children = gameObject.GetComponentsInChildren<SkinnedMeshRenderer>().ToList();
-
+            var children = gameObject.GetComponentsInChildren<SkinnedMeshRenderer>().ToList();
+            if (ignoreNullMesh)
+            {
+                children = children.Where(renderer => renderer.sharedMesh != null).ToList();
+            }
             if (children.Count == 0)
             {
 


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-926](https://ready-player-me.atlassian.net/browse/SDK-926)

## Description

-   This improves the get mesh renderer function to optionally filter for null skin meshes. This is useful when you are using the AvatarTemplate prefab which has all possible skinnedmeshrenders (for mesh transfer purposes). Old functionality would return the first head mesh out of these three "Renderer_Head", "Renderer_Avatar", "Renderer_Head_Custom" regardless of whether they were empty or not which causes the eye blinking not to work. 
- I also added an extra UpdateHeadMesh() method which would be useful if you want to find and set the head mesh from code, the usecase would be if you are loading avatars with different configurations EG Texture atlas and non texture atlassed using the mesh transfer technique

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-  1 way to test would be to simply drag the RPM_Template_Avatar_XR prefab into the scene and add the EyeAnimationHandler and run to see if the blinking works.
- 

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



