### PR TITLE
[SDK-934] - initialize request in property

### DIFF
--- a/Runtime/AvatarCreator/Scripts/UI/Elements/AssetSelectionElement.cs
+++ b/Runtime/AvatarCreator/Scripts/UI/Elements/AssetSelectionElement.cs
@@ -21,11 +21,12 @@ namespace ReadyPlayerMe.AvatarCreator
         [SerializeField] private int iconSize = 64;
 
         private PartnerAsset[] assets;
+        
         private AssetAPIRequests assetsRequests;
+        private AssetAPIRequests AssetsRequests => assetsRequests ??= new AssetAPIRequests(CoreSettingsHandler.CoreSettings.AppId);
 
         private void Awake()
         {
-            assetsRequests = new AssetAPIRequests(CoreSettingsHandler.CoreSettings.AppId);
             if (clearSelectionButton == null) return;
             AddClearButton(clearSelectionButton, assetType);
         }
@@ -52,7 +53,7 @@ namespace ReadyPlayerMe.AvatarCreator
         /// <returns>A Task representing the asynchronous operation of fetching and loading the partner asset data.</returns>
         public async Task LoadAssetData(OutfitGender gender)
         {
-            assets = await assetsRequests.Get(assetType, bodyType, gender);
+            assets = await AssetsRequests.Get(assetType, bodyType, gender);
         }
 
         /// <summary>

--- a/Runtime/Core/Scripts/Animation/EyeAnimationHandler.cs
+++ b/Runtime/Core/Scripts/Animation/EyeAnimationHandler.cs
@@ -103,7 +103,7 @@ namespace ReadyPlayerMe.Core
         public void UpdateHeadMesh()
         {
             headMesh = gameObject.GetMeshRenderer(MeshType.HeadMesh, true);
-            HasBlinkBlendshapes();
+            hasBlinkBlendShapes = HasBlinkBlendshapes();
         }
 
         private bool HasBlinkBlendshapes()


### PR DESCRIPTION
## [SDK-934](https://ready-player-me.atlassian.net/browse/SDK-934)

## Description

-   Remove race condition, when assetSelectionElement is disabled, but it is initialized before it is enabled.

## How to Test

-   When assetSelectionElement is disabled, you can still load the buttons.




[SDK-934]: https://ready-player-me.atlassian.net/browse/SDK-934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ