### PR TITLE
fix: check if the lod file update time is creater than the updated av…

### DIFF
--- a/Runtime/Core/Scripts/Operations/MetadataDownloader.cs
+++ b/Runtime/Core/Scripts/Operations/MetadataDownloader.cs
@@ -129,7 +129,17 @@ namespace ReadyPlayerMe.Core
                 return true;
             }
             AvatarMetadata previousMetadata = AvatarMetadata.LoadFromFile(context.AvatarUri.LocalMetadataPath);
-            return AvatarMetadata.IsUpdated(context.Metadata, previousMetadata);
+            return AvatarMetadata.IsUpdated(context.Metadata, previousMetadata) || ShouldUpdateAvatarFile(context);
+        }
+
+        private static bool ShouldUpdateAvatarFile(AvatarContext context)
+        {
+            if (!File.Exists(context.AvatarUri.LocalModelPath))
+            {
+                return true;
+            }
+            var avatarFileUpdateTime = File.GetLastWriteTime(context.AvatarUri.LocalModelPath);
+            return avatarFileUpdateTime < context.Metadata.UpdatedAt.ToLocalTime();
         }
 
         /// <summary>

--- a/Runtime/Core/Scripts/Operations/MetadataDownloader.cs
+++ b/Runtime/Core/Scripts/Operations/MetadataDownloader.cs
@@ -138,8 +138,8 @@ namespace ReadyPlayerMe.Core
             {
                 return true;
             }
-            var avatarFileUpdateTime = File.GetLastWriteTime(context.AvatarUri.LocalModelPath);
-            return avatarFileUpdateTime < context.Metadata.UpdatedAt.ToLocalTime();
+            var avatarFileUpdateTime = File.GetLastWriteTimeUtc(context.AvatarUri.LocalModelPath);
+            return avatarFileUpdateTime < context.Metadata.UpdatedAt;
         }
 
         /// <summary>


### PR DESCRIPTION
## [SDK-718](https://ready-player-me.atlassian.net/browse/SDK-718)

## Description

-   issues with LOD's and avatars not being updated, when cache is enabled.

## How to Test

- Create an avatar online with any application
- load avatar with LOD sample (paste avatar URL and load for the first time)
- update same avatar in the web
- verify, that the avatar is updated for all of the LODs





[SDK-718]: https://ready-player-me.atlassian.net/browse/SDK-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ