### PR TITLE
feat: log error, when bodyshapes are not enabled in studio

### DIFF
--- a/Runtime/AvatarCreator/Scripts/Managers/AvatarManager.cs
+++ b/Runtime/AvatarCreator/Scripts/Managers/AvatarManager.cs
@@ -303,9 +303,6 @@ namespace ReadyPlayerMe.AvatarCreator
         /// <param name="assetId">Asset ID</param>
         private async Task ValidateBodyShapeUpdate(AssetType assetType, object assetId)
         {
-#if !UNITY_EDITOR
-            return;               
-#endif
             if (assetType != AssetType.BodyShape)
             {
                 return;

--- a/Runtime/AvatarCreator/Scripts/Managers/AvatarManager.cs
+++ b/Runtime/AvatarCreator/Scripts/Managers/AvatarManager.cs
@@ -290,17 +290,22 @@ namespace ReadyPlayerMe.AvatarCreator
             {
                 return null;
             }
-            
-#if UNITY_EDITOR
-            await ValidateAssetUpdate(assetType, assetId);
-#endif
+            await ValidateBodyShapeUpdate(assetType, assetId);
+
 
             return await inCreatorAvatarLoader.Load(avatarId, bodyType, gender, data);
         }
         
-#if UNITY_EDITOR
-        private async Task ValidateAssetUpdate(AssetType assetType, object assetId)
+        /// <summary>
+        /// Function that checks if body shapes are enabled in the studio. This validation is performed only in the editor.
+        /// </summary>
+        /// <param name="assetType">Assets type that was updated</param>
+        /// <param name="assetId">Asset ID</param>
+        private async Task ValidateBodyShapeUpdate(AssetType assetType, object assetId)
         {
+#if !UNITY_EDITOR
+            return;               
+#endif
             if (assetType != AssetType.BodyShape)
             {
                 return;
@@ -314,7 +319,6 @@ namespace ReadyPlayerMe.AvatarCreator
             }
             Debug.LogError(ERROR_BODYSHAPES_NOT_ENABLED);
         }
-#endif
         
 
         public async Task<Dictionary<AssetType, AssetColor[]>> LoadAvatarColors()


### PR DESCRIPTION
## [SDK-907](https://ready-player-me.atlassian.net/browse/SDK-907)

## Description

-   Throw error, when body shapes are not enabled in the studio
<img width="1415" alt="image" src="https://github.com/readyplayerme/rpm-unity-sdk-core/assets/107070960/dd264de4-63ea-45b1-a32a-84d207bc5804">


## How to Test

- Enable body shapes in the studio and test, that shapes are applied and that no error is thrown
- Disable body shapes in the studio and verify, that error is shown and avatar is not updated

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-907]: https://ready-player-me.atlassian.net/browse/SDK-907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ