### PR TITLE
fix: allow cache to be loaded from previous versions, where bodyType was stored as an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.3.1] - 2024.05.03
+
+### Fixed
+
+- Cache can load now avatars from previous versions, that had bodytype set as an integer [#292](https://github.com/readyplayerme/rpm-unity-sdk-core/pull/292)
+
 ## [6.3.0] - 2024.06.11
 
 ### Updated

--- a/Editor/Core/Scripts/UI/CustomEditors/AvatarConfigEditor.cs
+++ b/Editor/Core/Scripts/UI/CustomEditors/AvatarConfigEditor.cs
@@ -154,6 +154,12 @@ namespace ReadyPlayerMe.Core.Editor
                         }
                     }
                     useDracoCompression.SetValueWithoutNotify(avatarConfigTarget.UseDracoCompression);
+                    if (avatarConfigTarget.UseDracoCompression && avatarConfigTarget.UseMeshOptCompression)
+                    {
+                        Debug.LogWarning("Draco compression is not compatible with Mesh Optimization compression. Mesh Optimization compression will be disabled.");
+                        avatarConfigTarget.UseMeshOptCompression = false;
+                        useMeshOptCompression.SetValueWithoutNotify(false);
+                    }
                     Save();
                 }
             );
@@ -178,6 +184,12 @@ namespace ReadyPlayerMe.Core.Editor
                         }
                     }
                     useMeshOptCompression.SetValueWithoutNotify(avatarConfigTarget.UseMeshOptCompression);
+                    if (avatarConfigTarget.UseMeshOptCompression && avatarConfigTarget.UseDracoCompression)
+                    {
+                        Debug.LogWarning("Mesh Optimization compression is not compatible with Draco compression. Draco compression will be disabled.");
+                        avatarConfigTarget.UseDracoCompression = false;
+                        useDracoCompression.SetValueWithoutNotify(false);
+                    }
                     Save();
                 }
             );

--- a/Editor/Core/Scripts/UI/CustomEditors/AvatarConfigEditor.cs
+++ b/Editor/Core/Scripts/UI/CustomEditors/AvatarConfigEditor.cs
@@ -127,62 +127,57 @@ namespace ReadyPlayerMe.Core.Editor
         {
             var useDracoCompression = root.Q<Toggle>("UseDracoCompression");
             var useMeshOptCompression = root.Q<Toggle>("UseMeshOptCompression");
-
             var optimizationPackages = root.Q<Foldout>("OptimizationPackages");
             optimizationPackages.RegisterValueChangedCallback(x =>
             {
-                useDracoCompression.SetValueWithoutNotify(ModuleInstaller.IsModuleInstalled(ModuleList.DracoCompression.name));
-                useMeshOptCompression.SetValueWithoutNotify(PackageManagerHelper.IsPackageInstalled(MESH_OPT_PACKAGE_NAME));
+                useDracoCompression.SetValueWithoutNotify(avatarConfigTarget.UseDracoCompression);
+                useMeshOptCompression.SetValueWithoutNotify(avatarConfigTarget.UseMeshOptCompression);
             });
 
             useDracoCompression.RegisterValueChangedCallback(x =>
                 {
+                    if (avatarConfigTarget.UseDracoCompression == x.newValue) return;
                     avatarConfigTarget.UseDracoCompression = x.newValue;
-                    if (ModuleInstaller.IsModuleInstalled(ModuleList.DracoCompression.name))
+                    if (!ModuleInstaller.IsModuleInstalled(ModuleList.DracoCompression.name))
                     {
-                        return;
+                        if (EditorUtility.DisplayDialog(
+                                DIALOG_TITLE,
+                                string.Format(DIALOG_MESSAGE, "Draco compression", ModuleList.DracoCompression.name),
+                                DIALOG_OK,
+                                DIALOG_CANCEL))
+                        {
+                            ModuleInstaller.AddModuleRequest(ModuleList.DracoCompression.Identifier);
+                        }
+                        else
+                        {
+                            avatarConfigTarget.UseDracoCompression = false;
+                        }
                     }
-
-                    if (EditorUtility.DisplayDialog(
-                            DIALOG_TITLE,
-                            string.Format(DIALOG_MESSAGE, "Draco compression", ModuleList.DracoCompression.name),
-                            DIALOG_OK,
-                            DIALOG_CANCEL))
-                    {
-                        ModuleInstaller.AddModuleRequest(ModuleList.DracoCompression.Identifier);
-                    }
-                    else
-                    {
-                        avatarConfigTarget.UseDracoCompression = false;
-                        useDracoCompression.SetValueWithoutNotify(false);
-                    }
-
+                    useDracoCompression.SetValueWithoutNotify(avatarConfigTarget.UseDracoCompression);
                     Save();
                 }
             );
 
             useMeshOptCompression.RegisterValueChangedCallback(x =>
                 {
+                    if (avatarConfigTarget.UseMeshOptCompression == x.newValue) return;
                     avatarConfigTarget.UseMeshOptCompression = x.newValue;
-                    if (PackageManagerHelper.IsPackageInstalled(MESH_OPT_PACKAGE_NAME))
+                    if (!PackageManagerHelper.IsPackageInstalled(MESH_OPT_PACKAGE_NAME))
                     {
-                        return;
+                        if (EditorUtility.DisplayDialog(
+                                DIALOG_TITLE,
+                                string.Format(DIALOG_MESSAGE, "Mesh opt compression", MESH_OPT_PACKAGE_NAME),
+                                DIALOG_OK,
+                                DIALOG_CANCEL))
+                        {
+                            PackageManagerHelper.AddPackage(MESH_OPT_PACKAGE_NAME);
+                        }
+                        else
+                        {
+                            avatarConfigTarget.UseMeshOptCompression = false;
+                        }
                     }
-
-                    if (EditorUtility.DisplayDialog(
-                            DIALOG_TITLE,
-                            string.Format(DIALOG_MESSAGE, "Mesh opt compression", MESH_OPT_PACKAGE_NAME),
-                            DIALOG_OK,
-                            DIALOG_CANCEL))
-                    {
-                        PackageManagerHelper.AddPackage(MESH_OPT_PACKAGE_NAME);
-                    }
-                    else
-                    {
-                        avatarConfigTarget.UseMeshOptCompression = false;
-                        useMeshOptCompression.SetValueWithoutNotify(false);
-                    }
-
+                    useMeshOptCompression.SetValueWithoutNotify(avatarConfigTarget.UseMeshOptCompression);
                     Save();
                 }
             );

--- a/Runtime/Core/Scripts/Data/ApplicationData.cs
+++ b/Runtime/Core/Scripts/Data/ApplicationData.cs
@@ -6,7 +6,7 @@ namespace ReadyPlayerMe.Core
 {
     public static class ApplicationData
     {
-        public const string SDK_VERSION = "v6.3.0";
+        public const string SDK_VERSION = "v6.3.1";
         private const string TAG = "ApplicationData";
         private const string DEFAULT_RENDER_PIPELINE = "Built-In Render Pipeline";
         private static readonly AppData Data;

--- a/Runtime/Core/Scripts/JsonConverters/BodyTypeConverter.cs
+++ b/Runtime/Core/Scripts/JsonConverters/BodyTypeConverter.cs
@@ -33,7 +33,13 @@ namespace ReadyPlayerMe.Core
                 };
             }
 
-            throw new JsonSerializationException("Expected string value, instead found: " + token.Type);
+            // This is a fallback to the previous SDK versions, where the bodyType was stored as an Integer.
+            if (token.Type == JTokenType.Integer)
+            {
+                return (BodyType) token.Value<int>();
+            }
+
+            throw new JsonSerializationException("Expected string or integer value, instead found: " + token.Type);
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.readyplayerme.core",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "displayName": "Ready Player Me Core",
   "description": "This Module contains all the core functionality required for using Ready Player Me avatars in Unity, including features such as: \n - Module management and automatic package setup logic\n - Avatar loading from .glb files \n - Avatar creation \n - Avatar and 2D render requests \n - Optional Analytics\n - Custom editor windows\n - Sample scenes and assets",
   "unity": "2020.3",


### PR DESCRIPTION
## Description

-   Previous versions stored the body type as an integer. This is fixed, so that they can be now loaded as an integer.

## How to Test

-   Save the avatar in the cache in version 5.0.0 for example, then update SDK to the latest and verify, that the avatars can be still loaded.



