### PR TITLE
feat: preserve property Id from asset data

### DIFF
--- a/Runtime/AvatarCreator/Scripts/Interfaces/IAssetData.cs
+++ b/Runtime/AvatarCreator/Scripts/Interfaces/IAssetData.cs
@@ -1,7 +1,10 @@
+using UnityEngine.Scripting;
+
 namespace ReadyPlayerMe.AvatarCreator
 {
     public interface IAssetData
     {
+        [Preserve]
         public string Id { get; set; }
         public AssetType AssetType { get; set; }
     }


### PR DESCRIPTION
[SRV-1333](https://ready-player-me.atlassian.net/browse/SRV-1333)

## Description

-   Preserve the Id from the IAsset interface, so when stripped in mobile it does not remove it

## How to Test

-   Build a sdk version for android using stripping level high, try to run it in the android emulator




[SRV-1333]: https://ready-player-me.atlassian.net/browse/SRV-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ