### PR TITLE
Remove Response and specify the type needed to avoid extra allocation coming from DownloadHandler.Text

### DIFF
--- a/Runtime/AvatarCreator/Scripts/Extensions/ResponseExtensions.cs
+++ b/Runtime/AvatarCreator/Scripts/Extensions/ResponseExtensions.cs
@@ -14,7 +14,7 @@ namespace ReadyPlayerMe.AvatarCreator
             }
         }
 
-        public static void ThrowIfError(this Response response)
+        public static void ThrowIfError(this ResponseText response)
         {
             if (!response.IsSuccess)
             {

--- a/Runtime/AvatarCreator/Scripts/WebRequests/AssetAPIRequests.cs
+++ b/Runtime/AvatarCreator/Scripts/WebRequests/AssetAPIRequests.cs
@@ -98,7 +98,7 @@ namespace ReadyPlayerMe.AvatarCreator
 
             var url = BuildAssetListUrl(type, limit, pageNumber, AuthManager.UserSession.Id, appId, gender == OutfitGender.Masculine ? "male" : "female");
 
-            var response = await authorizedRequest.SendRequest<Response>(new RequestData
+            var response = await authorizedRequest.SendRequest<ResponseText>(new RequestData
             {
                 Url = url,
                 Method = HttpMethod.GET

--- a/Runtime/AvatarCreator/Scripts/WebRequests/AuthAPIRequests.cs
+++ b/Runtime/AvatarCreator/Scripts/WebRequests/AuthAPIRequests.cs
@@ -38,7 +38,7 @@ namespace ReadyPlayerMe.AvatarCreator
 
         public async Task<UserSession> LoginAsAnonymous(CancellationToken cancellationToken = default)
         {
-            var response = await webRequestDispatcher.SendRequest<Response>($"{rpmAuthBaseUrl}/users", HttpMethod.POST, headers, ctx:cancellationToken);
+            var response = await webRequestDispatcher.SendRequest<ResponseText>($"{rpmAuthBaseUrl}/users", HttpMethod.POST, headers, ctx:cancellationToken);
             response.ThrowIfError();
 
             var data = AuthDataConverter.ParseResponse(response.Text);
@@ -60,7 +60,7 @@ namespace ReadyPlayerMe.AvatarCreator
 
             var payload = AuthDataConverter.CreatePayload(data);
 
-            var response = await webRequestDispatcher.SendRequest<Response>($"{rpmAuthBaseUrl}/auth/start", HttpMethod.POST, headers, payload, ctx:cancellationToken);
+            var response = await webRequestDispatcher.SendRequest<ResponseText>($"{rpmAuthBaseUrl}/auth/start", HttpMethod.POST, headers, payload, ctx:cancellationToken);
             response.ThrowIfError();
         }
 
@@ -76,7 +76,7 @@ namespace ReadyPlayerMe.AvatarCreator
             }
             var payload = AuthDataConverter.CreatePayload(body);
 
-            var response = await webRequestDispatcher.SendRequest<Response>($"{rpmAuthBaseUrl}/auth/login", HttpMethod.POST, headers, payload, ctx:cancellationToken);
+            var response = await webRequestDispatcher.SendRequest<ResponseText>($"{rpmAuthBaseUrl}/auth/login", HttpMethod.POST, headers, payload, ctx:cancellationToken);
             response.ThrowIfError();
 
             var data = AuthDataConverter.ParseResponse(response.Text);
@@ -93,7 +93,7 @@ namespace ReadyPlayerMe.AvatarCreator
             };
 
             var payload = AuthDataConverter.CreatePayload(data);
-            var response = await webRequestDispatcher.SendRequest<Response>($"{rpmAuthBaseUrl}/auth/start", HttpMethod.POST, headers, payload, ctx:cancellationToken);
+            var response = await webRequestDispatcher.SendRequest<ResponseText>($"{rpmAuthBaseUrl}/auth/start", HttpMethod.POST, headers, payload, ctx:cancellationToken);
             response.ThrowIfError();
         }
 
@@ -122,7 +122,7 @@ namespace ReadyPlayerMe.AvatarCreator
                 { AuthConstants.REFRESH_TOKEN, refreshToken }
             });
 
-            var response = await webRequestDispatcher.SendRequest<Response>(url, HttpMethod.POST, headers, payload, ctx:cancellationToken);
+            var response = await webRequestDispatcher.SendRequest<ResponseText>(url, HttpMethod.POST, headers, payload, ctx:cancellationToken);
             response.ThrowIfError();
 
             return AuthDataConverter.ParseResponse(response.Text);

--- a/Runtime/AvatarCreator/Scripts/WebRequests/AvatarAPIRequests.cs
+++ b/Runtime/AvatarCreator/Scripts/WebRequests/AvatarAPIRequests.cs
@@ -34,7 +34,7 @@ namespace ReadyPlayerMe.AvatarCreator
 
         public async Task<List<UserAvatarResponse>> GetUserAvatars(string userId)
         {
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseText>(
                 new RequestData
                 {
                     Url = $"{RPM_AVATAR_V1_BASE_URL}/?userId={userId}&select={ID},{PARTNER},{DATA}.{BODY_TYPE}",
@@ -58,7 +58,7 @@ namespace ReadyPlayerMe.AvatarCreator
 
         public async Task<List<AvatarTemplateData>> GetAvatarTemplates()
         {
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseText>(
                 new RequestData
                 {
                     Url = $"{RPM_AVATAR_V2_BASE_URL}/templates?{BODY_TYPE}={CoreSettingsHandler.CoreSettings.BodyType.GetDescription()}",
@@ -83,7 +83,7 @@ namespace ReadyPlayerMe.AvatarCreator
 
             var payload = AuthDataConverter.CreatePayload(payloadData);
 
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseText>(
                 new RequestData
                 {
                     Url = $"{RPM_AVATAR_V2_BASE_URL}/templates/{templateId}",
@@ -109,7 +109,7 @@ namespace ReadyPlayerMe.AvatarCreator
                 colorParameters = "skin,beard,hair,eyebrow";
             }
 
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseText>(
                 new RequestData
                 {
                     Url = $"{RPM_AVATAR_V2_BASE_URL}/{avatarId}/colors?type={colorParameters}",
@@ -130,7 +130,7 @@ namespace ReadyPlayerMe.AvatarCreator
             if (isDraft)
                 url += "preview=true";
 
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseText>(
                 new RequestData
                 {
                     Url = url,
@@ -148,7 +148,7 @@ namespace ReadyPlayerMe.AvatarCreator
 
         public async Task<AvatarProperties> CreateNewAvatar(AvatarProperties avatarProperties)
         {
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseText>(
                 new RequestData
                 {
                     Url = RPM_AVATAR_V2_BASE_URL,
@@ -175,7 +175,7 @@ namespace ReadyPlayerMe.AvatarCreator
             if (isPreview)
                 url += "preview=true";
 
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseData>(
                 new RequestData
                 {
                     Url = url,
@@ -192,7 +192,7 @@ namespace ReadyPlayerMe.AvatarCreator
             ValidateAvatarId(avatarId);
             var url = $"{RPM_AVATAR_V2_BASE_URL}/{avatarId}.json?";
 
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseText>(
                 new RequestData
                 {
                     Url = url,
@@ -211,7 +211,7 @@ namespace ReadyPlayerMe.AvatarCreator
             ValidateAvatarId(avatarId);
             var url = $"{RPM_AVATAR_V2_BASE_URL}/{avatarId}?responseType=glb&{parameters}";
 
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseData>(
                 new RequestData
                 {
                     Url = url,
@@ -228,7 +228,7 @@ namespace ReadyPlayerMe.AvatarCreator
             ValidateAvatarId(avatarId);
             var json = JsonConvert.SerializeObject(precompileData);
 
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseText>(
                 new RequestData
                 {
                     Url = $"{RPM_AVATAR_V2_BASE_URL}/{avatarId}/precompile?{parameters ?? string.Empty}",
@@ -243,7 +243,7 @@ namespace ReadyPlayerMe.AvatarCreator
         public async Task<string> SaveAvatar(string avatarId)
         {
             ValidateAvatarId(avatarId);
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseText>(
                 new RequestData
                 {
                     Url = $"{RPM_AVATAR_V2_BASE_URL}/{avatarId}",
@@ -263,7 +263,7 @@ namespace ReadyPlayerMe.AvatarCreator
             if (isDraft)
                 url += "draft";
 
-            var response = await authorizedRequest.SendRequest<Response>(
+            var response = await authorizedRequest.SendRequest<ResponseText>(
                 new RequestData
                 {
                     Url = url,

--- a/Runtime/Core/Scripts/Analytics/AmplitudeEventLogger.cs
+++ b/Runtime/Core/Scripts/Analytics/AmplitudeEventLogger.cs
@@ -81,7 +81,7 @@ namespace ReadyPlayerMe.Core.Analytics
             }
 
             var webRequestDispatcher = new WebRequestDispatcher();
-            var response = await webRequestDispatcher.SendRequest<Response>(url, HttpMethod.POST, CommonHeaders.GetHeadersWithAppId(), payload);
+            var response = await webRequestDispatcher.SendRequest<ResponseText>(url, HttpMethod.POST, CommonHeaders.GetHeadersWithAppId(), payload);
 
             if (!response.IsSuccess)
             {

--- a/Runtime/Core/Scripts/Data/Response.cs.meta
+++ b/Runtime/Core/Scripts/Data/Response.cs.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: d39ab182772d4251ab0513ad2c601af1
-timeCreated: 1680726656

--- a/Runtime/Core/Scripts/Data/ResponseData.cs
+++ b/Runtime/Core/Scripts/Data/ResponseData.cs
@@ -2,9 +2,8 @@
 
 namespace ReadyPlayerMe.Core
 {
-    public class Response : IResponse
+    public class ResponseData : IResponse
     {
-        public string Text;
         public byte[] Data;
 
         public bool IsSuccess { get; set; }
@@ -18,7 +17,6 @@ namespace ReadyPlayerMe.Core
                 return;
             }
 
-            Text = request.downloadHandler.text;
             Data = request.downloadHandler.data;
         }
     }

--- a/Runtime/Core/Scripts/Data/ResponseData.cs.meta
+++ b/Runtime/Core/Scripts/Data/ResponseData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d303caaa8544cb14f890780f9a351900

--- a/Runtime/Core/Scripts/Data/ResponseText.cs
+++ b/Runtime/Core/Scripts/Data/ResponseText.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine.Networking;
+
+namespace ReadyPlayerMe.Core
+{
+    public class ResponseText : IResponse
+    {
+        public string Text;
+
+        public bool IsSuccess { get; set; }
+        public string Error { get; set; }
+        public long ResponseCode { get; set; }
+
+        public void Parse(UnityWebRequest request)
+        {
+            if (request.downloadHandler is DownloadHandlerFile)
+            {
+                return;
+            }
+
+            Text = request.downloadHandler.text;
+        }
+    }
+}

--- a/Runtime/Core/Scripts/Data/ResponseText.cs.meta
+++ b/Runtime/Core/Scripts/Data/ResponseText.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e10c8c31cb527bf479d936ea81ee04fd

--- a/Runtime/Core/Scripts/Extensions/WebRequestDispatcherExtension.cs
+++ b/Runtime/Core/Scripts/Extensions/WebRequestDispatcherExtension.cs
@@ -21,15 +21,15 @@ namespace ReadyPlayerMe.Core
 
         /// <summary>
         /// This asynchronous method makes GET request to the <paramref name="url" /> and returns the data in the
-        /// <see cref="Response" />.
+        /// <see cref="IResponse" />.
         /// </summary>
         /// <param name="webRequestDispatcher">WebRequestDispatcher object</param>
         /// <param name="url">The URL to make the <see cref="UnityWebRequest" /> to.</param>
         /// <param name="token">Can be used to cancel the operation.</param>
         /// <param name="timeout">The number of seconds to wait for the WebRequest to finish before aborting.</param>
-        /// <returns>A <see cref="Response" /> if successful otherwise it will throw an exception.</returns>
-        public static async Task<Response> DownloadIntoMemory(this WebRequestDispatcher webRequestDispatcher, string url, CancellationToken token,
-            int timeout = TIMEOUT)
+        /// <returns>A <see cref="IResponse" /> if successful otherwise it will throw an exception.</returns>
+        public static async Task<T> DownloadIntoMemory<T>(this WebRequestDispatcher webRequestDispatcher, string url, CancellationToken token,
+            int timeout = TIMEOUT) where T : IResponse, new()
         {
             if (!HasInternetConnection)
             {
@@ -45,7 +45,7 @@ namespace ReadyPlayerMe.Core
             headers.Add(CommonHeaders.GetAppIdHeader());
 
             webRequestDispatcher.Timeout = timeout;
-            var response = await webRequestDispatcher.SendRequest<Response>(url, HttpMethod.GET, headers, ctx: token);
+            var response = await webRequestDispatcher.SendRequest<T>(url, HttpMethod.GET, headers, ctx: token);
             token.ThrowCustomExceptionIfCancellationRequested();
 
             if (!response.IsSuccess)

--- a/Runtime/Core/Scripts/Operations/AvatarDownloader.cs
+++ b/Runtime/Core/Scripts/Operations/AvatarDownloader.cs
@@ -105,7 +105,7 @@ namespace ReadyPlayerMe.Core
 
             try
             {
-                var response = await dispatcher.DownloadIntoMemory(url, token, Timeout);
+                var response = await dispatcher.DownloadIntoMemory<ResponseData>(url, token, Timeout);
                 return response.Data;
             }
             catch (CustomException exception)

--- a/Runtime/Core/Scripts/Operations/MetadataDownloader.cs
+++ b/Runtime/Core/Scripts/Operations/MetadataDownloader.cs
@@ -83,7 +83,7 @@ namespace ReadyPlayerMe.Core
                 // add random tail to the url to prevent JSON from being loaded from the browser cache
                 var response = await dispatcher.DownloadIntoMemory(url + "?tail=" + Guid.NewGuid(), token, Timeout);
 #else
-                Response response = await dispatcher.DownloadIntoMemory(url, token, Timeout);
+                ResponseText response = await dispatcher.DownloadIntoMemory<ResponseText>(url, token, Timeout);
 #endif
                 return ParseResponse(response.Text);
             }


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.atlassian.net/browse/TICKETID)

## Description

-   Briefly describe what this change will do
There is an issue with avatar loader when cache is disabled this is meant to fix it by avoiding the call to downloadHandler.Text when attempting to push it.

## How to Test

-  Attempt to load avatar with caching disable and observe a spike in profiler
-  With this PR observe no spike is happening.

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.



