### PR TITLE
Fix VoiceHandler memory access out of bounds on WebGL

### DIFF
--- a/Runtime/Core/Scripts/Animation/VoiceHandler.cs
+++ b/Runtime/Core/Scripts/Animation/VoiceHandler.cs
@@ -169,7 +169,7 @@ namespace ReadyPlayerMe.Core
             {
                 var currentPosition = AudioSource.timeSamples;
                 var remaining = AudioSource.clip.samples - currentPosition;
-                if (remaining > 0 && remaining < AUDIO_SAMPLE_LENGTH)
+                if (remaining >= 0 && remaining < AUDIO_SAMPLE_LENGTH)
                 {
                     return 0f;
                 }


### PR DESCRIPTION
## Description

This should fix issue #323, where for some AudioClip lengths the GetAmplitude method tried to read data from the clip even if the remaining samples were 0.

## How to Test

- add VoiceHandler component on an avatar
- set build target to webGL and run the built application
- let the AudioSource referenced by the VoiceHandler reproduce AudioClips with various lengths

## Checklist

- [ ] Tests written or updated for the changes.
- [ ] Documentation is updated.
- [ ] Changelog is updated.
