### PR TITLE
Improve avatar config handling

### DIFF
--- a/Editor/Core/Scripts/UI/EditorWindows/SetupGuide/SetupGuide.cs
+++ b/Editor/Core/Scripts/UI/EditorWindows/SetupGuide/SetupGuide.cs
@@ -1,5 +1,4 @@
 using ReadyPlayerMe.Core.Analytics;
-using ReadyPlayerMe.Core.Data;
 using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine;

--- a/Runtime/Core/Scripts/Utils/AvatarAPIParameters.cs
+++ b/Runtime/Core/Scripts/Utils/AvatarAPIParameters.cs
@@ -7,6 +7,7 @@ namespace ReadyPlayerMe.Core
         public const string TEXTURE_ATLAS = "textureAtlas";
         public const string TEXTURE_SIZE_LIMIT = "textureSizeLimit";
         public const string TEXTURE_CHANNELS = "textureChannels";
+        public const string TEXTURE_FORMAT = "textureFormat";
         public const string MORPH_TARGETS = "morphTargets";
         public const string USE_HANDS = "useHands";
         public const string USE_DRACO = "useDracoMeshCompression";

--- a/Runtime/Core/Scripts/Utils/AvatarConfigProcessor.cs
+++ b/Runtime/Core/Scripts/Utils/AvatarConfigProcessor.cs
@@ -34,6 +34,11 @@ namespace ReadyPlayerMe.Core
             {
                 queryBuilder.AddKeyValue(AvatarAPIParameters.MORPH_TARGETS, CombineMorphTargetNames(avatarConfig.MorphTargets));
             }
+            else
+            {
+                // If no morph targets are set, we set the value to "none" to prevent unwanted blendshapes.
+                queryBuilder.AddKeyValue(AvatarAPIParameters.MORPH_TARGETS, "none");
+            }
             queryBuilder.AddKeyValue(AvatarAPIParameters.USE_HANDS, GetBoolStringValue(avatarConfig.UseHands));
             queryBuilder.AddKeyValue(AvatarAPIParameters.USE_DRACO, GetBoolStringValue(avatarConfig.UseDracoCompression));
             queryBuilder.AddKeyValue(AvatarAPIParameters.USE_MESHOPT, GetBoolStringValue(avatarConfig.UseMeshOptCompression));

--- a/Runtime/Core/Scripts/Utils/AvatarConfigProcessor.cs
+++ b/Runtime/Core/Scripts/Utils/AvatarConfigProcessor.cs
@@ -42,6 +42,7 @@ namespace ReadyPlayerMe.Core
             queryBuilder.AddKeyValue(AvatarAPIParameters.USE_HANDS, GetBoolStringValue(avatarConfig.UseHands));
             queryBuilder.AddKeyValue(AvatarAPIParameters.USE_DRACO, GetBoolStringValue(avatarConfig.UseDracoCompression));
             queryBuilder.AddKeyValue(AvatarAPIParameters.USE_MESHOPT, GetBoolStringValue(avatarConfig.UseMeshOptCompression));
+            queryBuilder.AddKeyValue(AvatarAPIParameters.TEXTURE_FORMAT, "jpeg");
 
             return queryBuilder.Query;
         }

--- a/Runtime/Core/Scripts/Utils/WebRequestDispatcher.cs
+++ b/Runtime/Core/Scripts/Utils/WebRequestDispatcher.cs
@@ -44,7 +44,6 @@ namespace ReadyPlayerMe.Core
                     request.SetRequestHeader(header.Key, header.Value);
                 }
             }
-
             downloadHandler ??= new DownloadHandlerBuffer();
 
             request.downloadHandler = downloadHandler;


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.atlassian.net/browse/TICKETID)

## Description

-   This PR updates the handling of avatar config adding  the use of textureFormat=jpeg by default which will ensure correct texture format (no webp support)
- Also now if no blenshapes are set in the config it will be set to none by default to prevent unexpected blendshapes being added

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   Add steps to locally test these changes

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



