### PR TITLE
feat(colors): mark avatar's equipped colors as selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ Steps for trying out avatar creator sample can be found [here.](Documentation~/A
 A guide for customizing avatar creator can be found [here.](Documentation~/CustomizationGuide.md)
 
 ### Note
-- [*]Camera support is only provided for Windows and WebGL, using Unity’s webcam native API.
+- Camera support is only provided for Windows and WebGL, using Unity’s webcam native API.
 - Unity does not have a native file picker, so we have discontinued support for this feature.
 - To add support for file picker (for selfies) you have to implement it yourself

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/AssetButtonCreator.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/AssetButtonCreator.cs
@@ -83,7 +83,7 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
                     button.SetColor(assetColor.HexColor);
 
                     int equippedValue = 0;
-                    if (colorAssets.TryGetValue(assetColor.AssetType, out var value)) 
+                    if (colorAssets.TryGetValue(assetColor.AssetType, out var value))
                     {
                         equippedValue = value;
                     }
@@ -176,31 +176,31 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
                 case AssetType.Top:
                 case AssetType.Bottom:
                 case AssetType.Footwear:
-                {
-                    if (selectedButtonsByCategory.TryGetValue(AssetType.Outfit, out AssetButton outfitButton))
                     {
-                        outfitButton.SetSelect(false);
+                        if (selectedButtonsByCategory.TryGetValue(AssetType.Outfit, out AssetButton outfitButton))
+                        {
+                            outfitButton.SetSelect(false);
+                        }
+                        break;
                     }
-                    break;
-                }
                 case AssetType.Outfit:
-                {
-                    if (selectedButtonsByCategory.TryGetValue(AssetType.Top, out AssetButton topButton))
                     {
-                        topButton.SetSelect(false);
-                    }
+                        if (selectedButtonsByCategory.TryGetValue(AssetType.Top, out AssetButton topButton))
+                        {
+                            topButton.SetSelect(false);
+                        }
 
-                    if (selectedButtonsByCategory.TryGetValue(AssetType.Bottom, out AssetButton bottomButton))
-                    {
-                        bottomButton.SetSelect(false);
-                    }
+                        if (selectedButtonsByCategory.TryGetValue(AssetType.Bottom, out AssetButton bottomButton))
+                        {
+                            bottomButton.SetSelect(false);
+                        }
 
-                    if (selectedButtonsByCategory.TryGetValue(AssetType.Footwear, out AssetButton footwearButton))
-                    {
-                        footwearButton.SetSelect(false);
+                        if (selectedButtonsByCategory.TryGetValue(AssetType.Footwear, out AssetButton footwearButton))
+                        {
+                            footwearButton.SetSelect(false);
+                        }
+                        break;
                     }
-                    break;
-                }
             }
         }
 

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/AssetButtonCreator.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/AssetButtonCreator.cs
@@ -71,7 +71,7 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
             SelectButton(category, buttonsById[assetId]);
         }
 
-        public void CreateColorUI(Dictionary<AssetType, AssetColor[]> colorLibrary, Action<object, AssetType> onClick)
+        public void CreateColorUI(Dictionary<AssetType, AssetColor[]> colorLibrary, Action<object, AssetType> onClick, Dictionary<AssetType, int> colorAssets)
         {
             foreach (var colorPalette in colorLibrary)
             {
@@ -82,8 +82,13 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
                     var button = AddColorButton(assetIndex, parent.transform, colorPalette.Key, onClick);
                     button.SetColor(assetColor.HexColor);
 
-                    // By default first color is applied on initial draft
-                    if (assetIndex == 0)
+                    int equippedValue = 0;
+                    if (colorAssets.TryGetValue(assetColor.AssetType, out var value)) 
+                    {
+                        equippedValue = value;
+                    }
+
+                    if (assetIndex == equippedValue)
                     {
                         SelectButton(colorPalette.Key, button);
                     }

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -201,13 +201,30 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
         {
             var startTime = Time.time;
             var colors = await avatarManager.LoadAvatarColors();
-            
-            var colorAssetTypes = AssetFilterHelper.GetAssetTypesByFilter(AssetFilter.Color).ToHashSet();
-            var equippedColors = AvatarCreatorData.AvatarProperties.Assets.Where(kvp => colorAssetTypes.Contains(kvp.Key))
-                     .ToDictionary(kvp => kvp.Key, kvp => Convert.ToInt32(kvp.Value));
+            var equippedColors = GetEquippedColors();
 
             assetButtonCreator.CreateColorUI(colors, UpdateAvatar, equippedColors);
             SDKLogger.Log(TAG, $"All colors loaded in {Time.time - startTime:F2}s");
+        }
+
+        private Dictionary<AssetType, int> GetEquippedColors()
+        {
+            var colorAssetTypes = AssetFilterHelper.GetAssetTypesByFilter(AssetFilter.Color).ToHashSet();
+            return AvatarCreatorData.AvatarProperties.Assets
+            .Where(kvp => colorAssetTypes.Contains(kvp.Key))
+            .ToDictionary(
+                kvp => kvp.Key,
+                kvp =>
+                {
+                    try
+                    {
+                        return Convert.ToInt32(kvp.Value);
+                    }
+                    catch
+                    {
+                        return 0;
+                    }
+                });
         }
 
         private void CreateUI()

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -209,7 +209,7 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
 
         private Dictionary<AssetType, int> GetEquippedColors()
         {
-            var colorAssetTypes = AssetFilterHelper.GetAssetTypesByFilter(AssetFilter.Color).ToHashSet();
+            var colorAssetTypes = AssetTypeHelper.GetAssetTypesByFilter(AssetFilter.Color).ToHashSet();
             return AvatarCreatorData.AvatarProperties.Assets
             .Where(kvp => colorAssetTypes.Contains(kvp.Key))
             .ToDictionary(

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -202,24 +202,12 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
             var startTime = Time.time;
             var colors = await avatarManager.LoadAvatarColors();
             
-            var colorAssetTypes = GetAssetTypesByFilter(AssetFilter.Color).ToHashSet();
+            var colorAssetTypes = AssetFilterHelper.GetAssetTypesByFilter(AssetFilter.Color).ToHashSet();
             var equippedColors = AvatarCreatorData.AvatarProperties.Assets.Where(kvp => colorAssetTypes.Contains(kvp.Key))
                      .ToDictionary(kvp => kvp.Key, kvp => Convert.ToInt32(kvp.Value));
 
             assetButtonCreator.CreateColorUI(colors, UpdateAvatar, equippedColors);
             SDKLogger.Log(TAG, $"All colors loaded in {Time.time - startTime:F2}s");
-        }
-
-        public static IEnumerable<AssetType> GetAssetTypesByFilter(AssetFilter filter)
-        {
-            return Enum.GetValues(typeof(AssetType))
-                .Cast<AssetType>()
-                .Where(assetType =>
-                {
-                    var fieldInfo = typeof(AssetType).GetField(assetType.ToString());
-                    var attribute = fieldInfo?.GetCustomAttribute<AssetTypeFilterAttribute>();
-                    return attribute?.filter == filter;
-                });
         }
 
         private void CreateUI()

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Reflection;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -171,6 +173,7 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
             else
             {
                 var id = AvatarCreatorData.AvatarProperties.Id;
+
                 if (!AvatarCreatorData.IsExistingAvatar)
                 {
                     var avatarTemplateResponse = await avatarManager.CreateAvatarFromTemplateAsync(id);
@@ -198,8 +201,25 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
         {
             var startTime = Time.time;
             var colors = await avatarManager.LoadAvatarColors();
-            assetButtonCreator.CreateColorUI(colors, UpdateAvatar);
+            
+            var colorAssetTypes = GetAssetTypesByFilter(AssetFilter.Color).ToHashSet();
+            var equippedColors = AvatarCreatorData.AvatarProperties.Assets.Where(kvp => colorAssetTypes.Contains(kvp.Key))
+                     .ToDictionary(kvp => kvp.Key, kvp => Convert.ToInt32(kvp.Value));
+
+            assetButtonCreator.CreateColorUI(colors, UpdateAvatar, equippedColors);
             SDKLogger.Log(TAG, $"All colors loaded in {Time.time - startTime:F2}s");
+        }
+
+        public static IEnumerable<AssetType> GetAssetTypesByFilter(AssetFilter filter)
+        {
+            return Enum.GetValues(typeof(AssetType))
+                .Cast<AssetType>()
+                .Where(assetType =>
+                {
+                    var fieldInfo = typeof(AssetType).GetField(assetType.ToString());
+                    var attribute = fieldInfo?.GetCustomAttribute<AssetTypeFilterAttribute>();
+                    return attribute?.filter == filter;
+                });
         }
 
         private void CreateUI()

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/Utils/AssetTypeHelper.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/Utils/AssetTypeHelper.cs
@@ -3,17 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using ReadyPlayerMe.AvatarCreator;
-public static class AssetTypeHelper
+
+namespace ReadyPlayerMe.Samples.AvatarCreatorWizard
 {
-    public static IEnumerable<AssetType> GetAssetTypesByFilter(AssetFilter filter)
+    public static class AssetTypeHelper
     {
-        return Enum.GetValues(typeof(AssetType))
-            .Cast<AssetType>()
-            .Where(assetType =>
-            {
-                var fieldInfo = typeof(AssetType).GetField(assetType.ToString());
-                var attribute = fieldInfo?.GetCustomAttribute<AssetTypeFilterAttribute>();
-                return attribute?.filter == filter;
-            });
+        public static IEnumerable<AssetType> GetAssetTypesByFilter(AssetFilter filter)
+        {
+            return Enum.GetValues(typeof(AssetType))
+                .Cast<AssetType>()
+                .Where(assetType =>
+                {
+                    var fieldInfo = typeof(AssetType).GetField(assetType.ToString());
+                    var attribute = fieldInfo?.GetCustomAttribute<AssetTypeFilterAttribute>();
+                    return attribute?.filter == filter;
+                });
+        }
     }
 }

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/Utils/AssetTypeHelper.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/Utils/AssetTypeHelper.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using ReadyPlayerMe.AvatarCreator;
+public static class AssetTypeHelper
+{
+    public static IEnumerable<AssetType> GetAssetTypesByFilter(AssetFilter filter)
+    {
+        return Enum.GetValues(typeof(AssetType))
+            .Cast<AssetType>()
+            .Where(assetType =>
+            {
+                var fieldInfo = typeof(AssetType).GetField(assetType.ToString());
+                var attribute = fieldInfo?.GetCustomAttribute<AssetTypeFilterAttribute>();
+                return attribute?.filter == filter;
+            });
+    }
+}


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SRV-1555](https://ready-player-me.atlassian.net/browse/SRV-1555)

## Description

-  Fixes https://github.com/readyplayerme/rpm-unity-sdk-core/issues/325. 
-  These changes ensure that equipped colors are now taken into account when loading an avatar, instead of defaulting to the first color.

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

- Open the AvatarCreatorWizard scene.
- Create a new avatar using the template.
- In the editor, navigate to the skin, eyebrow, hair, or beard category.
- Verify that the displayed color matches what the avatar is currently wearing.

https://github.com/user-attachments/assets/0a8c7992-ed94-4ece-8b66-9cf7bbbf2962


<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SRV-1555]: https://ready-player-me.atlassian.net/browse/SRV-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ