### PR TITLE
Improve handing of headwear equipping

### DIFF
--- a/Samples~/AvatarCreatorSamples/AvatarCreatorElements/Scripts/AvatarHandler.cs
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorElements/Scripts/AvatarHandler.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ReadyPlayerMe.AvatarCreator;
@@ -35,7 +38,18 @@ namespace ReadyPlayerMe.Samples.AvatarCreatorElements
         public async Task SelectAsset(IAssetData assetData)
         {
             OnAvatarLoading?.Invoke();
-            var newAvatar = await avatarManager.UpdateAsset(assetData.AssetType, assetData.Id);
+            GameObject newAvatar;
+            if(assetData.AssetType == AssetType.Headwear && ActiveAvatarProperties.Assets.ContainsKey(AssetType.HairStyle))
+            {
+                var assets = new Dictionary<AssetType, object>();
+                assets.Add(AssetType.HairStyle, ActiveAvatarProperties.Assets[AssetType.HairStyle]);
+                assets.Add(AssetType.Headwear, assetData.Id);
+                newAvatar = await avatarManager.UpdateAssets(assets);
+            }
+            else
+            {
+                newAvatar = await avatarManager.UpdateAsset(assetData.AssetType, assetData.Id);
+            }
             SetupLoadedAvatar(newAvatar, ActiveAvatarProperties);
         }
 

--- a/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/Utils/AssetTypeHelper.cs.meta
+++ b/Samples~/AvatarCreatorSamples/AvatarCreatorWizard/Scripts/Utils/AssetTypeHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6db2b85ffc40417478f7b3a97b15401e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.atlassian.net/browse/TICKETID)

## Description

-   This PR improves how headwear equipping is handled in the Avatar Creator elements 
- ThHis also adds an UpdateAssets function to the Avatar Manager so that you can equip multiple items at once making it easier to unequip the headwear and re-equip the hair at the same time.

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   Add steps to locally test these changes

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



