### PR TITLE
Fix/Update BodyTypeConverter.WriteJson to use EnumExtensions.GetDescription

### DIFF
--- a/Runtime/Core/Scripts/JsonConverters/BodyTypeConverter.cs
+++ b/Runtime/Core/Scripts/JsonConverters/BodyTypeConverter.cs
@@ -10,7 +10,7 @@ namespace ReadyPlayerMe.Core
     {
         public override void WriteJson(JsonWriter writer, BodyType value, JsonSerializer serializer)
         {
-            serializer.Serialize(writer, value.ToString().ToLower());
+            serializer.Serialize(writer, EnumExtensions.GetDescription(value));
         }
 
         public override BodyType ReadJson(JsonReader reader, Type objectType, BodyType existingValue, bool hasExistingValue,


### PR DESCRIPTION
Found that the `BodyType.FullBodyXR` was being written as `fullbodyxr` when the API only recognized `fullbody-xr`.

Using `EnumExtensions.GetDescription` appears to fix the issue.

